### PR TITLE
 Centralize user and doctor state handling with model helpers

### DIFF
--- a/app/core/interfaces/users.py
+++ b/app/core/interfaces/users.py
@@ -92,13 +92,20 @@ class UserRepository(BaseInterface):
         with Session(engine) as session:
             existing_user = UserRepository.get_user_by_email(email, session)
             if existing_user:
+                audit = existing_user.mark_login()
                 set_or_update_google_user(existing_user, user_data)
+                session.add(existing_user)
+                session.commit()
+                session.refresh(existing_user)
+                console.log(f"Google login audit: {audit}")
                 return existing_user, True
-            
+
+            audit = user.mark_login()
             session.add(user)
             session.commit()
             session.refresh(user)
 
             set_or_update_google_user(user, user_data)
-        
+            console.log(f"Google login audit: {audit}")
+
         return user, False

--- a/test/test_models_entities.py
+++ b/test/test_models_entities.py
@@ -1,0 +1,96 @@
+import pytest
+
+from datetime import datetime
+from uuid import uuid4
+
+from app.models import User, Doctors, DoctorStates
+
+
+def build_user(*, is_active: bool = True) -> User:
+    return User(
+        name="Test User",
+        email="user@example.com",
+        password="Password1!",
+        dni="12345678",
+        is_active=is_active,
+    )
+
+
+def build_doctor(*, is_active: bool = True) -> Doctors:
+    return Doctors(
+        name="Doc",
+        email="doc@example.com",
+        password="Password1!",
+        dni="87654321",
+        speciality_id=uuid4(),
+        is_active=is_active,
+    )
+
+
+def test_user_mark_login_updates_last_login_and_audit():
+    user = build_user()
+    reference = datetime(2024, 1, 1, 12, 0, 0)
+
+    audit = user.mark_login(timestamp=reference)
+
+    assert user.last_login == reference
+    assert audit.action == "mark_login"
+    assert audit.target_id == user.id
+    assert audit.details["timestamp"] == reference.isoformat()
+
+
+def test_user_mark_login_on_inactive_user_raises():
+    user = build_user(is_active=False)
+
+    with pytest.raises(ValueError):
+        user.mark_login()
+
+
+def test_user_activation_cycle_records_audit():
+    user = build_user()
+
+    deactivate_audit = user.deactivate(reason="policy violation")
+    assert not user.is_active
+    assert deactivate_audit.action == "deactivate"
+
+    with pytest.raises(ValueError):
+        user.deactivate()
+
+    activate_audit = user.activate()
+    assert user.is_active
+    assert activate_audit.action == "activate"
+
+    with pytest.raises(ValueError):
+        user.activate()
+
+
+def test_doctor_update_state_controls_availability():
+    doctor = build_doctor()
+
+    audit_busy = doctor.update_state(DoctorStates.busy)
+    assert doctor.doctor_state == DoctorStates.busy
+    assert not doctor.is_available
+    assert audit_busy.details["new_state"] == DoctorStates.busy.value
+
+    audit_available = doctor.update_state(DoctorStates.available)
+    assert doctor.doctor_state == DoctorStates.available
+    assert doctor.is_available
+    assert audit_available.details["new_state"] == DoctorStates.available.value
+
+
+def test_doctor_update_state_invalid_value_raises():
+    doctor = build_doctor()
+
+    with pytest.raises(ValueError):
+        doctor.update_state("invalid")  # type: ignore[arg-type]
+
+
+def test_doctor_ban_is_alias_of_deactivate():
+    doctor = build_doctor()
+
+    ban_audit = doctor.ban()
+    assert not doctor.is_active
+    assert ban_audit.action == "deactivate"
+
+    with pytest.raises(ValueError):
+        doctor.ban()


### PR DESCRIPTION
-----Summary-----
- add audit-aware helpers on BaseUser/Doctors and document where entity mutations happen
- refactor auth, user, and doctor endpoints plus the google user repository to call the new helpers instead of mutating fields inline
- cover the helpers with focused unit tests for users and doctors

-----Testing-----
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c /dev/null test/test_models_entities.py --maxfail=1 > /tmp/pytest.log 2>&1 (fails: ValueError because pytest terminal reporter plugin is registered twice in this environment)