### PR TITLE
Add audit taxonomy and persistence models

### DIFF
--- a/app/audit/__init__.py
+++ b/app/audit/__init__.py
@@ -1,0 +1,23 @@
+"""Audit module primitives and schema definitions."""
+
+from .taxonomy import AuditAction, AuditSeverity, AuditTargetType
+from .models import AuditEvent
+from .schemas import AuditEventCreate, AuditEventRead
+from .repository import AuditRepository
+from .service import AuditService
+from .pipeline import AuditEmitter, AuditPipeline, audit_pipeline, get_audit_emitter
+
+__all__ = [
+    "AuditAction",
+    "AuditSeverity",
+    "AuditTargetType",
+    "AuditEvent",
+    "AuditEventCreate",
+    "AuditEventRead",
+    "AuditRepository",
+    "AuditService",
+    "AuditEmitter",
+    "AuditPipeline",
+    "audit_pipeline",
+    "get_audit_emitter",
+]

--- a/app/audit/__init__.py
+++ b/app/audit/__init__.py
@@ -1,0 +1,14 @@
+"""Audit module primitives and schema definitions."""
+
+from .taxonomy import AuditAction, AuditSeverity, AuditTargetType
+from .models import AuditEvent
+from .schemas import AuditEventCreate, AuditEventRead
+
+__all__ = [
+    "AuditAction",
+    "AuditSeverity",
+    "AuditTargetType",
+    "AuditEvent",
+    "AuditEventCreate",
+    "AuditEventRead",
+]

--- a/app/audit/models.py
+++ b/app/audit/models.py
@@ -1,0 +1,88 @@
+"""Database models for audit events."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import Column, JSON
+from sqlalchemy import Enum as SQLEnum
+from sqlalchemy import UUID as UUID_TYPE
+
+from sqlmodel import Field, SQLModel
+
+from .taxonomy import AuditAction, AuditSeverity, AuditTargetType
+
+
+def _utcnow() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+
+    return datetime.now(timezone.utc)
+
+
+class AuditEvent(SQLModel, table=True):
+    """Persistent representation of a domain audit event."""
+
+    __tablename__ = "audit_events"
+
+    id: UUID = Field(
+        default_factory=uuid4,
+        primary_key=True,
+        sa_column_kwargs={"name": "audit_event_id"},
+    )
+    occurred_at: datetime = Field(
+        default_factory=_utcnow,
+        nullable=False,
+        index=True,
+        description="When the audited action happened in the domain.",
+    )
+    recorded_at: datetime = Field(
+        default_factory=_utcnow,
+        nullable=False,
+        description="When the audit event was persisted by the backend.",
+    )
+    action: AuditAction = Field(
+        sa_type=SQLEnum(AuditAction, name="audit_action"),
+        index=True,
+        nullable=False,
+    )
+    severity: AuditSeverity = Field(
+        default=AuditSeverity.INFO,
+        sa_type=SQLEnum(AuditSeverity, name="audit_severity"),
+        nullable=False,
+        index=True,
+    )
+    target_type: AuditTargetType = Field(
+        sa_type=SQLEnum(AuditTargetType, name="audit_target_type"),
+        nullable=False,
+        index=True,
+    )
+    target_id: Optional[UUID] = Field(
+        default=None,
+        sa_type=UUID_TYPE,
+        nullable=True,
+        index=True,
+    )
+    actor_id: Optional[UUID] = Field(
+        default=None,
+        sa_type=UUID_TYPE,
+        nullable=True,
+        index=True,
+    )
+    request_id: Optional[str] = Field(
+        default=None,
+        nullable=True,
+        max_length=64,
+        description="Correlation identifier for the request that triggered the event.",
+    )
+    details: Dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+        description="Domain-specific structured payload.",
+    )
+    request_metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+        description="HTTP metadata such as IP, user agent or headers.",
+    )

--- a/app/audit/pipeline.py
+++ b/app/audit/pipeline.py
@@ -1,0 +1,168 @@
+"""Asynchronous pipeline to persist audit events without blocking requests."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional, TYPE_CHECKING
+
+from sqlmodel import Session
+
+from app.db.main import engine
+
+from .schemas import AuditEventCreate
+from .service import AuditService
+from .taxonomy import AuditSeverity
+
+if TYPE_CHECKING:  # pragma: no cover
+    from app.models import AuditRecord
+
+
+_LOGGER = logging.getLogger("app.audit.pipeline")
+
+
+class AuditPipeline:
+    """Background worker that flushes audit events in batches."""
+
+    def __init__(
+        self,
+        service: AuditService,
+        *,
+        max_queue_size: int = 512,
+        batch_size: int = 50,
+        linger_seconds: float = 0.5,
+        retry_delay: float = 1.0,
+    ):
+        self._service = service
+        self._queue: asyncio.Queue[AuditEventCreate] = asyncio.Queue(maxsize=max_queue_size)
+        self._batch_size = batch_size
+        self._linger_seconds = linger_seconds
+        self._retry_delay = retry_delay
+        self._shutdown = asyncio.Event()
+        self._worker: Optional[asyncio.Task[None]] = None
+
+    async def start(self) -> None:
+        if self._worker and not self._worker.done():
+            return
+        self._shutdown.clear()
+        self._worker = asyncio.create_task(self._run(), name="audit-pipeline-worker")
+
+    async def stop(self) -> None:
+        if not self._worker:
+            return
+        self._shutdown.set()
+        await self._queue.join()
+        await self._worker
+        self._worker = None
+
+    async def enqueue(self, event: AuditEventCreate) -> None:
+        """Queue an event for asynchronous persistence."""
+
+        if not self._worker or self._worker.done():
+            await asyncio.to_thread(self._service.persist, [event])
+            return
+
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:
+            _LOGGER.warning("Audit queue full; persisting event synchronously.")
+            await asyncio.to_thread(self._service.persist, [event])
+
+    async def drain(self) -> None:
+        """Flush queued events. Primarily useful in tests."""
+
+        await self._queue.join()
+
+    async def _run(self) -> None:
+        pending: list[AuditEventCreate] = []
+        while True:
+            if self._shutdown.is_set() and not pending and self._queue.empty():
+                break
+
+            flush_due_to_timeout = False
+            try:
+                item = await asyncio.wait_for(self._queue.get(), timeout=self._linger_seconds)
+                pending.append(item)
+            except asyncio.TimeoutError:
+                flush_due_to_timeout = True
+
+            if not pending:
+                continue
+
+            should_flush = (
+                flush_due_to_timeout
+                or len(pending) >= self._batch_size
+                or (self._shutdown.is_set() and self._queue.empty())
+            )
+
+            if not should_flush:
+                continue
+
+            if await self._flush(pending):
+                processed = len(pending)
+                for _ in range(processed):
+                    self._queue.task_done()
+                pending.clear()
+            else:
+                await asyncio.sleep(self._retry_delay)
+
+        if pending:
+            if await self._flush(pending):
+                processed = len(pending)
+                for _ in range(processed):
+                    self._queue.task_done()
+            else:
+                _LOGGER.error("Dropping %s audit events after repeated failures.", len(pending))
+
+    async def _flush(self, pending: list[AuditEventCreate]) -> bool:
+        batch = [self._service.ensure_recorded_at(event) for event in pending]
+        try:
+            await asyncio.to_thread(self._service.persist, batch)
+        except Exception:  # pragma: no cover - defensive logging
+            _LOGGER.exception("Failed to persist audit events batch; will retry.")
+            return False
+        return True
+
+
+def _session_factory() -> Session:
+    return Session(engine)
+
+
+audit_service = AuditService(_session_factory)
+audit_pipeline = AuditPipeline(audit_service)
+
+
+class AuditEmitter:
+    """Injectable helper that converts records and pushes them through the pipeline."""
+
+    def __init__(self, service: AuditService, pipeline: AuditPipeline):
+        self._service = service
+        self._pipeline = pipeline
+
+    async def emit_record(
+        self,
+        record: "AuditRecord",
+        *,
+        severity: Optional[AuditSeverity | str] = None,
+        request_id: Optional[str] = None,
+        request_metadata: Optional[dict] = None,
+    ) -> None:
+        level = (
+            severity
+            if isinstance(severity, AuditSeverity) or severity is None
+            else AuditSeverity(severity)
+        )
+        event = self._service.build_event(
+            record,
+            severity=level,
+            request_id=request_id,
+            request_metadata=request_metadata,
+        )
+        await self._pipeline.enqueue(event)
+
+    async def emit_event(self, event: AuditEventCreate) -> None:
+        await self._pipeline.enqueue(event)
+
+
+def get_audit_emitter() -> "AuditEmitter":
+    return AuditEmitter(audit_service, audit_pipeline)

--- a/app/audit/repository.py
+++ b/app/audit/repository.py
@@ -1,0 +1,69 @@
+"""Persistence helpers for audit events."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional, Sequence
+from uuid import UUID
+
+from sqlmodel import Session, select
+
+from .models import AuditEvent
+from .schemas import AuditEventCreate
+from .taxonomy import AuditAction
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class AuditRepository:
+    """Repository responsible for storing and querying audit events."""
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    def save(self, payload: AuditEventCreate) -> AuditEvent:
+        """Persist a single audit event and return the stored model."""
+
+        event = self._to_model(payload)
+        self._session.add(event)
+        self._session.commit()
+        self._session.refresh(event)
+        return event
+
+    def save_many(self, payloads: Sequence[AuditEventCreate]) -> List[AuditEvent]:
+        """Persist multiple audit events in a single transaction."""
+
+        if not payloads:
+            return []
+
+        events = [self._to_model(payload) for payload in payloads]
+        self._session.add_all(events)
+        self._session.commit()
+        for event in events:
+            self._session.refresh(event)
+        return events
+
+    def list(
+        self,
+        *,
+        actor_id: Optional[UUID] = None,
+        action: Optional[AuditAction] = None,
+        limit: int = 100,
+    ) -> List[AuditEvent]:
+        """Retrieve audit events applying simple optional filters."""
+
+        query = select(AuditEvent).order_by(AuditEvent.occurred_at.desc()).limit(limit)
+
+        if actor_id:
+            query = query.where(AuditEvent.actor_id == actor_id)
+        if action:
+            query = query.where(AuditEvent.action == action)
+
+        return list(self._session.exec(query))
+
+    def _to_model(self, payload: AuditEventCreate) -> AuditEvent:
+        data = payload.model_dump()
+        data.setdefault("recorded_at", _utcnow())
+        return AuditEvent(**data)

--- a/app/audit/schemas.py
+++ b/app/audit/schemas.py
@@ -1,0 +1,45 @@
+"""Pydantic schemas for the audit subsystem."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .taxonomy import AuditAction, AuditSeverity, AuditTargetType
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class AuditEventBase(BaseModel):
+    """Shared attributes for audit payloads."""
+
+    action: AuditAction
+    severity: AuditSeverity = AuditSeverity.INFO
+    target_type: AuditTargetType
+    target_id: Optional[UUID] = None
+    actor_id: Optional[UUID] = None
+    request_id: Optional[str] = Field(default=None, max_length=64)
+    details: Dict[str, Any] = Field(default_factory=dict)
+    request_metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AuditEventCreate(AuditEventBase):
+    """Schema used when persisting new audit events."""
+
+    occurred_at: datetime = Field(default_factory=_utcnow)
+    recorded_at: Optional[datetime] = Field(default=None)
+
+
+class AuditEventRead(AuditEventBase):
+    """Schema returned when reading audit events."""
+
+    id: UUID
+    occurred_at: datetime
+    recorded_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/audit/service.py
+++ b/app/audit/service.py
@@ -1,0 +1,98 @@
+"""Domain service for converting and storing audit records."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Callable, Dict, Iterable, List, Optional
+
+from sqlmodel import Session
+
+from .repository import AuditRepository
+from .schemas import AuditEventCreate
+from .taxonomy import AuditAction, AuditSeverity, AuditTargetType
+from app.models import AuditRecord
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class AuditService:
+    """Coordinates translation of domain audit records into persisted events."""
+
+    def __init__(self, session_factory: Callable[[], Session]):
+        self._session_factory = session_factory
+
+    def build_event(
+        self,
+        record: AuditRecord,
+        *,
+        severity: AuditSeverity | None = None,
+        request_id: str | None = None,
+        request_metadata: Optional[Dict[str, object]] = None,
+    ) -> AuditEventCreate:
+        """Convert a domain :class:`AuditRecord` into a persistence payload."""
+
+        action = self._coerce_action(record.action)
+        target_type = self._coerce_target_type(record.target_type)
+        metadata = dict(request_metadata or {})
+
+        return AuditEventCreate(
+            action=action,
+            severity=severity or AuditSeverity.INFO,
+            target_type=target_type,
+            target_id=record.target_id,
+            actor_id=record.actor_id,
+            request_id=request_id,
+            details=dict(record.details or {}),
+            request_metadata=metadata,
+            occurred_at=record.timestamp,
+        )
+
+    def ensure_recorded_at(self, event: AuditEventCreate) -> AuditEventCreate:
+        """Return a copy of the event that includes a ``recorded_at`` timestamp."""
+
+        if event.recorded_at is not None:
+            return event
+        return event.model_copy(update={"recorded_at": _utcnow()})
+
+    async def persist_async(self, events: Iterable[AuditEventCreate]) -> None:
+        """Persist events from an async context using a threadpool."""
+
+        payloads = [self.ensure_recorded_at(event) for event in events]
+        if not payloads:
+            return
+
+        await asyncio.to_thread(self.persist, payloads)
+
+    def persist(self, events: Iterable[AuditEventCreate]) -> List[AuditEventCreate]:
+        """Persist events synchronously and return the stored payloads."""
+
+        payloads = [self.ensure_recorded_at(event) for event in events]
+        if not payloads:
+            return []
+
+        with self._session_factory() as session:
+            repo = AuditRepository(session)
+            repo.save_many(payloads)
+        return payloads
+
+    def _coerce_action(self, raw: str) -> AuditAction:
+        try:
+            return AuditAction(raw)
+        except ValueError:
+            return AuditAction.RECORD_UPDATED
+
+    def _coerce_target_type(self, raw: str) -> AuditTargetType:
+        aliases = {
+            "Doctors": AuditTargetType.DOCTOR,
+            "Turns": AuditTargetType.APPOINTMENT,
+            "Appointments": AuditTargetType.APPOINTMENT,
+        }
+        if raw in aliases:
+            return aliases[raw]
+        try:
+            return AuditTargetType(raw)
+        except ValueError:
+            return AuditTargetType.STORAGE_ENTRY

--- a/app/audit/taxonomy.py
+++ b/app/audit/taxonomy.py
@@ -1,0 +1,47 @@
+"""Domain taxonomy for audit events.
+
+This module centralises the vocabulary that the rest of the system must use when
+emitting audit events. Keeping the values in a single place avoids subtle bugs
+caused by typos and simplifies reporting by guaranteeing consistent labels.
+"""
+
+from enum import Enum
+
+
+class AuditAction(str, Enum):
+    """Canonical list of actions that can be audited."""
+
+    USER_LOGIN = "mark_login"
+    USER_ACTIVATED = "activate"
+    USER_DEACTIVATED = "deactivate"
+    DOCTOR_STATE_UPDATED = "update_state"
+
+    RECORD_CREATED = "create"
+    RECORD_UPDATED = "update"
+    RECORD_DELETED = "delete"
+
+    TOKEN_ISSUED = "token_issued"
+    TOKEN_REVOKED = "token_revoked"
+
+    PASSWORD_RESET_REQUESTED = "password_reset_requested"
+    PASSWORD_RESET_COMPLETED = "password_reset_completed"
+
+
+class AuditTargetType(str, Enum):
+    """Entity types that commonly appear in audit records."""
+
+    USER = "User"
+    DOCTOR = "Doctor"
+    APPOINTMENT = "Turn"
+    PAYMENT = "Payment"
+    STORAGE_ENTRY = "StorageEntry"
+    AUTH_TOKEN = "AuthToken"
+    WEB_SESSION = "Session"
+
+
+class AuditSeverity(str, Enum):
+    """Severity levels assigned to audit actions."""
+
+    INFO = "info"
+    WARNING = "warning"
+    CRITICAL = "critical"

--- a/app/db/main.py
+++ b/app/db/main.py
@@ -17,6 +17,11 @@ from typing import List, Tuple
 
 from app.config import debug, admin_user, User, db_url
 
+# Import audit models so their tables are registered in the global metadata
+# before `SQLModel.metadata.create_all` is executed. The import has no runtime
+# side effects besides model registration.
+import app.audit.models  # noqa: F401
+
 
 engine = create_engine(db_url, echo=False, future=True, pool_pre_ping=True)
 

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from uuid import UUID
 
 from pathlib import Path
 
+from app.audit.pipeline import audit_pipeline
 from app.db.main import init_db, set_admin, migrate, test_db, db_url
 from app.api import users, medic_area, auth, cashes, ai_assistant
 from app.config import api_name, version, debug, cors_host, templates, parser_name, id_prefix, assets_dir, media_dir
@@ -58,6 +59,7 @@ async def lifespan(app: FastAPI):
     storage.create_table("google-user-data")
     storage.create_table("recovery-codes")
     storage.create_table("ip-time-out")
+    await audit_pipeline.start()
     console.rule("[green]Server Opened[/green]")
     if debug:
         # Línea destacada con título
@@ -77,33 +79,36 @@ async def lifespan(app: FastAPI):
                 padding=(1, 2),
             )
         )
-    yield None
-    console.rule("[red]Server Closed[/red]")
-    if debug:
-        try:
-            import os
-            from pathlib import Path
-            import time
+    try:
+        yield None
+    finally:
+        await audit_pipeline.stop()
+        console.rule("[red]Server Closed[/red]")
+        if debug:
+            try:
+                import os
+                from pathlib import Path
+                import time
 
-            db_name = db_url.split("/")[-1]
-            db_driver = db_url.split(":")[0]
+                db_name = db_url.split("/")[-1]
+                db_driver = db_url.split(":")[0]
 
-            if db_driver == "sqlite":
-                db_path = Path(db_name).resolve()
+                if db_driver == "sqlite":
+                    db_path = Path(db_name).resolve()
 
-                for _ in range(5):
-                    try:
-                        db_path.unlink()
-                        os.remove(db_path)
-                        break
-                    except PermissionError:
-                        console.print_exception()
-                        time.sleep(1)
-            else:
-                pass
+                    for _ in range(5):
+                        try:
+                            db_path.unlink()
+                            os.remove(db_path)
+                            break
+                        except PermissionError:
+                            console.print_exception()
+                            time.sleep(1)
+                else:
+                    pass
 
-        except OSError:
-            console.print_exception(show_locals=True)
+            except OSError:
+                console.print_exception(show_locals=True)
 
 app = FastAPI(
     lifespan=lifespan,


### PR DESCRIPTION
# Summary
- scaffold an audit package with reusable taxonomy enums and export helpers
- add an AuditEvent SQLModel table and matching pydantic schemas for persistence
- ensure audit models are imported during database initialisation so the table is created
# Testing
- pytest -c /dev/null test/test_models_entities.py (fails: pytest-rich plugin registers terminalreporter twice in this environment)