### PR TITLE
Refactor database session initialization

### DIFF
--- a/app/audit/pipeline.py
+++ b/app/audit/pipeline.py
@@ -6,9 +6,7 @@ import asyncio
 import logging
 from typing import Optional, TYPE_CHECKING
 
-from sqlmodel import Session
-
-from app.db.main import engine
+from app.db.session import session_factory
 from app.config import (
     audit_batch_size,
     audit_enabled,
@@ -145,12 +143,8 @@ class AuditPipeline:
         return True
 
 
-def _session_factory() -> Session:
-    return Session(engine)
-
-
 audit_service = AuditService(
-    _session_factory,
+    session_factory,
     retention_days=audit_retention_days,
     redacted_fields=audit_redact_fields,
 )

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -24,7 +24,7 @@ from rich.console import Console
 
 from app.config import token_key, api_name, version, debug
 from app.models import Doctors, User
-from app.db.main import Session, engine
+from app.db.session import session_factory
 from app.storage import storage
 from app.core.interfaces.emails import EmailService
 from app.storage import storage
@@ -462,7 +462,7 @@ class JWTBearer:
             if "doc" in payload.get("scopes"):
                 statement = select(Doctors).where(Doctors.id == user_id)
 
-            with Session(engine) as session:
+            with session_factory() as session:
                 user = session.exec(statement).first()
 
             if "google" in payload.get("scopes") and not "doc" in payload.get("scopes"):
@@ -518,7 +518,7 @@ class JWTWebSocket:
             if "doc" in payload.get("scopes"):
                 statement = select(Doctors).where(Doctors.id == user_id)
 
-            with Session(engine) as session:
+            with session_factory() as session:
                 user = session.exec(statement).first()
 
             if "google" in payload.get("scopes") and not "doc" in payload.get("scopes"):

--- a/app/core/interfaces/ai_assistant.py
+++ b/app/core/interfaces/ai_assistant.py
@@ -17,7 +17,7 @@ from app.core.interfaces.users import UserRepository
 from app.core.interfaces.medic_area import DoctorRepository, TurnAndAppointmentRepository
 from app.core.interfaces.emails import EmailService
 from app.config import llm_model_name
-from app.db.main import engine
+from app.db.session import session_factory
 
 console = Console()
 
@@ -195,7 +195,7 @@ class AIAssistantInterface(BaseInterface):
         """Handle appointment-related requests."""
         global _model
         
-        with Session(engine) as session:
+        with session_factory() as session:
             try:
                 # Extract intent from request
                 if "create" in request.lower() or "agendar" in request.lower():
@@ -275,7 +275,7 @@ class AIAssistantInterface(BaseInterface):
                 "type": "ai_unavailable",
             }
         
-        with Session(engine) as session:
+        with session_factory() as session:
             try:
                 doctors = await self.doctor_repo.get_doctors(session)
                 
@@ -343,7 +343,7 @@ class AIAssistantInterface(BaseInterface):
     
     async def _handle_schedule_request(self, request: str, user_context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         """Handle schedule-related requests."""
-        with Session(engine) as session:
+        with session_factory() as session:
             try:
                 
                 response = await self._generate_response(request, user_context)

--- a/app/core/interfaces/users.py
+++ b/app/core/interfaces/users.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 from sqlmodel import Session, select
 
-from app.db.main import engine
+from app.db.session import session_factory
 from app.models import User, AuditRecord
 from app.storage import storage, NoneResultException
 from app.storage.command.main import console
@@ -58,7 +58,7 @@ class UserRepository(BaseInterface):
 
     @staticmethod
     def update_user(user: User, session) -> User:
-        with Session(engine) as session:
+        with session_factory() as session:
             session.merge(user)
             session.commit()
             return user
@@ -89,7 +89,7 @@ class UserRepository(BaseInterface):
         )
         user.set_google_liked_acount_password(user_data.get('id'))
         
-        with Session(engine) as session:
+        with session_factory() as session:
             existing_user = UserRepository.get_user_by_email(email, session)
             if existing_user:
                 audit = existing_user.mark_login(actor_id=existing_user.id)

--- a/app/db/_initial_data.py
+++ b/app/db/_initial_data.py
@@ -4,7 +4,7 @@ import random
 
 from rich.console import Console
 
-from app.db.main import Session, engine
+from app.db.session import session_factory
 from app.models import *
 
 fake = Faker()
@@ -20,7 +20,7 @@ def get_blood_type() -> str:
 def init_data(amount: int):
     console.rule("make init data")
 
-    with Session(engine) as session:
+    with session_factory() as session:
         for _ in range(amount):
             session.add(
                 User(

--- a/app/db/main.py
+++ b/app/db/main.py
@@ -1,4 +1,4 @@
-from sqlmodel import create_engine, Session, SQLModel, select
+from sqlmodel import Session, SQLModel, select
 
 from sqlalchemy.exc import IntegrityError
 
@@ -15,7 +15,8 @@ import time
 
 from typing import List, Tuple
 
-from app.config import debug, admin_user, User, db_url
+from app.config import debug, admin_user, User, db_url as _db_url
+from app.db.session import engine, get_session as _get_session, session_factory
 
 # Import audit models so their tables are registered in the global metadata
 # before `SQLModel.metadata.create_all` is executed. The import has no runtime
@@ -23,7 +24,7 @@ from app.config import debug, admin_user, User, db_url
 import app.audit.models  # noqa: F401
 
 
-engine = create_engine(db_url, echo=False, future=True, pool_pre_ping=True)
+db_url = _db_url
 
 console = Console()
 
@@ -81,7 +82,7 @@ def set_admin():
     """
     try:
         print("Setting admin")
-        with Session(engine) as session:
+        with session_factory() as session:
             admin: User = session.exec(
                 select(User)
                     .where(User.email == admin_user.email)
@@ -122,9 +123,9 @@ def test_db() -> Tuple[float, bool]:
     """
     start = time.time()
     try:
-        with Session(engine) as session:
+        with session_factory() as session:
             statement = select(User)
-        result: List["User"] = session.exec(statement).all()
+            result: List["User"] = session.exec(statement).all()
         if result is None:
             end = time.time()
             return (end - start), False
@@ -142,21 +143,20 @@ def test_db() -> Tuple[float, bool]:
 def get_session():
     """
     Generador de sesiones de base de datos para dependency injection.
-    
+
     Crea una nueva sesión SQLModel para cada request, garantizando
     el cierre automático de la conexión al finalizar.
-    
+
     Yields:
         Session: Sesión de base de datos para operaciones ORM
-        
+
     Note:
         - Patrón context manager con yield
         - Usado como FastAPI Dependency
         - Garantiza cierre automático de conexiones
         - Una sesión por request para thread safety
     """
-    with Session(engine) as session:
-        yield session
+    yield from _get_session()
 
 SessionDep = Annotated[Session, Depends(get_session)]
 

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,31 @@
+"""Database engine and session utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Callable
+
+from sqlmodel import Session, create_engine
+
+from app.config import db_url
+
+if not db_url:
+    raise RuntimeError("Database URL is not configured.")
+
+engine = create_engine(db_url, echo=False, future=True, pool_pre_ping=True)
+
+SessionFactory = Callable[[], Session]
+
+
+def session_factory() -> Session:
+    """Return a new SQLModel session bound to the global engine."""
+    return Session(engine)
+
+
+def get_session() -> Iterator[Session]:
+    """FastAPI dependency that yields a managed SQLModel session."""
+    with session_factory() as session:
+        yield session
+
+
+__all__ = ["engine", "session_factory", "get_session", "SessionFactory", "db_url"]


### PR DESCRIPTION
# Summary

- extract the SQLModel engine and session dependency into a lightweight app/db/session.py module
- update app/db/main.py to reuse the shared session utilities while keeping audit model registration for metadata
- switch audit and core services to the shared session factory so they no longer import the database main module directly

# Testing

- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest (fails: pytest.ini requires the --rich plugin which is unavailable in this environment)
