### PR TITLE
Fix audit event schema alignment and add regression tests

### DIFF
--- a/app/audit/schemas.py
+++ b/app/audit/schemas.py
@@ -30,6 +30,8 @@ class AuditEventBase(BaseModel):
     details: Dict[str, Any] = Field(default_factory=dict)
     request_metadata: Dict[str, Any] = Field(default_factory=dict)
 
+    model_config = ConfigDict(use_enum_values=True)
+
 
 class AuditEventCreate(AuditEventBase):
     """Schema used when persisting new audit events."""
@@ -45,4 +47,4 @@ class AuditEventRead(AuditEventBase):
     occurred_at: datetime
     recorded_at: datetime
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)

--- a/app/audit/service.py
+++ b/app/audit/service.py
@@ -92,13 +92,26 @@ class AuditService:
                 repo.purge_older_than(cutoff)
         return payloads
 
-    def _coerce_action(self, raw: str) -> AuditAction:
+    def _coerce_action(self, raw: str | AuditAction) -> AuditAction:
+        if isinstance(raw, AuditAction):
+            return raw
+
         try:
             return AuditAction(raw)
         except ValueError:
-            return AuditAction.RECORD_UPDATED
+            try:
+                return AuditAction[raw]
+            except (KeyError, TypeError):
+                normalized = str(raw).lower() if raw is not None else ""
+                try:
+                    return AuditAction(normalized)
+                except ValueError:
+                    return AuditAction.RECORD_UPDATED
 
-    def _coerce_target_type(self, raw: str) -> AuditTargetType:
+    def _coerce_target_type(self, raw: str | AuditTargetType) -> AuditTargetType:
+        if isinstance(raw, AuditTargetType):
+            return raw
+
         aliases = {
             "Doctors": AuditTargetType.DOCTOR,
             "Turns": AuditTargetType.APPOINTMENT,

--- a/app/migrations/versions/1f2bdb0a3f76_sync_audit_events_schema.py
+++ b/app/migrations/versions/1f2bdb0a3f76_sync_audit_events_schema.py
@@ -1,0 +1,195 @@
+"""Bring the audit_events table in sync with the domain model.
+
+This migration is intentionally defensive: a few deployments ended up with an
+``audit_events`` table that predates the current ORM model.  When that happens
+the table is missing the ``action`` column altogether and the Postgres ENUM
+types do not contain the newest taxonomy values.  As a consequence every audit
+flush fails with ``UndefinedColumn`` and the pipeline keeps retrying forever.
+
+The migration below makes the schema compatible regardless of the previous
+state by:
+
+* Ensuring the ENUM types expose the complete list of allowed values.
+* Adding the missing ``action`` column (populating it from legacy columns when
+  possible) and creating the required index.
+* Recreating the whole table from scratch if it never existed in the first
+  place – this keeps fresh databases working exactly as before.
+
+Because Postgres ENUM additions are irreversible, the downgrade only drops the
+column/index that were created in the upgrade phase.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect, text
+
+
+# revision identifiers, used by Alembic.
+revision: str = "1f2bdb0a3f76"
+down_revision: Union[str, None] = "9b6655ff4200"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+AUDIT_ACTION_VALUES = [
+    "mark_login",
+    "login_failed",
+    "activate",
+    "deactivate",
+    "update_state",
+    "appointment_state_updated",
+    "create",
+    "update",
+    "delete",
+    "token_issued",
+    "token_revoked",
+    "token_invalid",
+    "rate_limit_triggered",
+    "password_reset_requested",
+    "password_reset_completed",
+    "payment_succeeded",
+    "payment_cancelled",
+    "payment_failed",
+    "turn_document_generated",
+    "turn_document_downloaded",
+]
+
+AUDIT_SEVERITY_VALUES = ["info", "warning", "critical"]
+
+AUDIT_TARGET_TYPE_VALUES = [
+    "User",
+    "Doctor",
+    "Turn",
+    "Payment",
+    "StorageEntry",
+    "AuthToken",
+    "Session",
+    "TurnDocument",
+]
+
+
+def _ensure_enum_values(bind, enum_name: str, values: list[str]) -> None:
+    """Append the provided values to an ENUM type if they are missing."""
+
+    has_type = bind.execute(
+        text("SELECT 1 FROM pg_type WHERE typname = :enum_name"),
+        {"enum_name": enum_name},
+    ).scalar()
+
+    if not has_type:
+        sa.Enum(*values, name=enum_name).create(bind, checkfirst=True)
+        existing: set[str] = set()
+    else:
+        existing = {
+            row[0]
+            for row in bind.execute(
+                text(
+                    "SELECT enumlabel FROM pg_enum "
+                    "JOIN pg_type ON pg_enum.enumtypid = pg_type.oid "
+                    "WHERE pg_type.typname = :enum_name"
+                ),
+                {"enum_name": enum_name},
+            )
+        }
+
+    for value in values:
+        if value not in existing:
+            bind.execute(text(f"ALTER TYPE {enum_name} ADD VALUE IF NOT EXISTS '{value}'"))
+            existing.add(value)
+
+
+def _create_audit_events_table(bind) -> None:
+    audit_action_enum = sa.Enum(*AUDIT_ACTION_VALUES, name="audit_action")
+    audit_severity_enum = sa.Enum(*AUDIT_SEVERITY_VALUES, name="audit_severity")
+    audit_target_type_enum = sa.Enum(*AUDIT_TARGET_TYPE_VALUES, name="audit_target_type")
+
+    audit_action_enum.create(bind, checkfirst=True)
+    audit_severity_enum.create(bind, checkfirst=True)
+    audit_target_type_enum.create(bind, checkfirst=True)
+
+    op.create_table(
+        "audit_events",
+        sa.Column("audit_event_id", sa.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("action", audit_action_enum, nullable=False),
+        sa.Column("severity", audit_severity_enum, nullable=False, server_default="info"),
+        sa.Column("target_type", audit_target_type_enum, nullable=False),
+        sa.Column("target_id", sa.UUID(as_uuid=True), nullable=True),
+        sa.Column("actor_id", sa.UUID(as_uuid=True), nullable=True),
+        sa.Column("request_id", sa.String(length=64), nullable=True),
+        sa.Column("details", sa.JSON(), nullable=False),
+        sa.Column("request_metadata", sa.JSON(), nullable=False),
+    )
+
+    op.create_index("ix_audit_events_occurred_at", "audit_events", ["occurred_at"])
+    op.create_index("ix_audit_events_action", "audit_events", ["action"])
+    op.create_index("ix_audit_events_severity", "audit_events", ["severity"])
+    op.create_index("ix_audit_events_target_type", "audit_events", ["target_type"])
+    op.create_index("ix_audit_events_target_id", "audit_events", ["target_id"])
+    op.create_index("ix_audit_events_actor_id", "audit_events", ["actor_id"])
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    table_names = set(inspector.get_table_names())
+
+    if "audit_events" not in table_names:
+        _create_audit_events_table(bind)
+        return
+
+    _ensure_enum_values(bind, "audit_action", AUDIT_ACTION_VALUES)
+    _ensure_enum_values(bind, "audit_severity", AUDIT_SEVERITY_VALUES)
+    _ensure_enum_values(bind, "audit_target_type", AUDIT_TARGET_TYPE_VALUES)
+
+    columns = inspector.get_columns("audit_events")
+    column_names = {column["name"] for column in columns}
+
+    if "action" not in column_names:
+        legacy_column = next(
+            (candidate for candidate in ("event", "event_action", "name", "type") if candidate in column_names),
+            None,
+        )
+
+        audit_action_enum = sa.Enum(
+            *AUDIT_ACTION_VALUES, name="audit_action", create_type=False
+        )
+
+        op.add_column(
+            "audit_events",
+            sa.Column("action", audit_action_enum, nullable=False, server_default="update"),
+        )
+
+        if legacy_column:
+            op.execute(
+                text(
+                    f"UPDATE audit_events SET action = LOWER({legacy_column}::text) "
+                    "WHERE action IS NULL OR action = 'update'"
+                )
+            )
+
+        op.execute(text("UPDATE audit_events SET action = 'update' WHERE action IS NULL"))
+        op.alter_column("audit_events", "action", server_default=None)
+
+    indexes = {index["name"] for index in inspector.get_indexes("audit_events")}
+    if "ix_audit_events_action" not in indexes:
+        op.create_index("ix_audit_events_action", "audit_events", ["action"])
+
+
+def downgrade() -> None:
+    inspector = inspect(op.get_bind())
+    table_names = set(inspector.get_table_names())
+    if "audit_events" not in table_names:
+        return
+
+    indexes = {index["name"] for index in inspector.get_indexes("audit_events")}
+    if "ix_audit_events_action" in indexes:
+        op.drop_index("ix_audit_events_action", table_name="audit_events")
+
+    columns = {column["name"] for column in inspector.get_columns("audit_events")}
+    if "action" in columns:
+        op.drop_column("audit_events", "action")

--- a/test/test_audit_pipeline.py
+++ b/test/test_audit_pipeline.py
@@ -1,0 +1,79 @@
+"""Regression tests for the audit persistence layer."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlmodel import SQLModel, Session, create_engine, select
+
+os.environ.setdefault("PASSLIB_PURE", "1")
+
+from app.audit.models import AuditEvent
+from app.audit.repository import AuditRepository
+from app.audit.schemas import AuditEventCreate
+from app.audit.service import AuditService
+from app.audit.taxonomy import AuditAction, AuditSeverity, AuditTargetType
+
+
+def _make_payload() -> AuditEventCreate:
+    return AuditEventCreate(
+        action=AuditAction.TOKEN_INVALID,
+        severity=AuditSeverity.WARNING,
+        target_type=AuditTargetType.AUTH_TOKEN,
+        target_id=uuid4(),
+        actor_id=uuid4(),
+        request_id="req-42",
+        details={"reason": "invalid_or_expired"},
+        request_metadata={"ip": "127.0.0.1"},
+        occurred_at=datetime.now(timezone.utc),
+    )
+
+
+def test_audit_payload_serializes_enum_values() -> None:
+    payload = _make_payload()
+    data = payload.model_dump()
+
+    assert data["action"] == "token_invalid"
+    assert data["severity"] == "warning"
+    assert data["target_type"] == "AuthToken"
+
+
+def test_audit_service_coerces_varied_actions() -> None:
+    service = AuditService(lambda: None)
+
+    assert service._coerce_action("token_invalid") is AuditAction.TOKEN_INVALID
+    assert service._coerce_action("TOKEN_INVALID") is AuditAction.TOKEN_INVALID
+    assert service._coerce_action(AuditAction.TOKEN_INVALID) is AuditAction.TOKEN_INVALID
+    assert service._coerce_action("does-not-exist") is AuditAction.RECORD_UPDATED
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("Doctor", AuditTargetType.DOCTOR),
+    ("Doctors", AuditTargetType.DOCTOR),
+    ("Turns", AuditTargetType.APPOINTMENT),
+    (AuditTargetType.AUTH_TOKEN, AuditTargetType.AUTH_TOKEN),
+    ("unknown", AuditTargetType.STORAGE_ENTRY),
+])
+def test_audit_service_coerces_target_types(raw, expected) -> None:
+    service = AuditService(lambda: None)
+    assert service._coerce_target_type(raw) is expected
+
+
+def test_repository_persists_audit_events(tmp_path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'audit.db'}", echo=False)
+    SQLModel.metadata.create_all(engine)
+
+    payload = _make_payload()
+
+    with Session(engine) as session:
+        repo = AuditRepository(session)
+        repo.save_many([payload])
+        stored = session.exec(select(AuditEvent)).first()
+
+    assert stored is not None
+    assert stored.action == AuditAction.TOKEN_INVALID
+    assert stored.severity == AuditSeverity.WARNING
+    assert stored.target_type == AuditTargetType.AUTH_TOKEN


### PR DESCRIPTION
# Summary
- add a defensive Alembic migration that recreates missing audit_events schema pieces and syncs enum values
- serialize audit enums consistently in schemas and make the audit service accept legacy inputs
- cover the repository flow with regression tests to ensure audit events persist correctly