### PR TITLE
Synchronize audit enums across application and database

### DIFF
--- a/app/audit/enum_utils.py
+++ b/app/audit/enum_utils.py
@@ -1,0 +1,116 @@
+"""Utilities for synchronising application enums with the database."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Mapping, Sequence
+
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import literal
+from sqlmodel import Session
+
+from .taxonomy import AuditAction, AuditSeverity, AuditTargetType
+
+_POSTGRES_DIALECT = postgresql.dialect()
+_PREPARER = _POSTGRES_DIALECT.identifier_preparer
+
+
+@dataclass(frozen=True)
+class EnumSyncState:
+    """Representation of the sync status for a single PostgreSQL enum type."""
+
+    name: str
+    expected_labels: Sequence[str]
+    database_labels: Sequence[str]
+
+    @property
+    def missing_labels(self) -> list[str]:
+        """Labels defined in code but not yet present in the database enum."""
+
+        existing = set(self.database_labels)
+        return [label for label in self.expected_labels if label not in existing]
+
+    @property
+    def statements(self) -> list[str]:
+        """SQL statements required to bring the database enum up to date."""
+
+        return [make_add_enum_value_sql(self.name, label) for label in self.missing_labels]
+
+
+AUDIT_ENUM_DEFINITIONS: Mapping[str, type[Enum]] = {
+    "audit_action": AuditAction,
+    "audit_severity": AuditSeverity,
+    "audit_target_type": AuditTargetType,
+}
+
+
+def enum_labels(enum: type[Enum]) -> list[str]:
+    """Return the values defined by an Enum as strings."""
+
+    return [member.value for member in enum]
+
+
+def database_enum_labels(session: Session, enum_name: str) -> list[str]:
+    """Read the labels currently registered for a PostgreSQL enum type."""
+
+    statement = text(
+        """
+        SELECT e.enumlabel
+        FROM pg_type t
+        JOIN pg_enum e ON t.oid = e.enumtypid
+        WHERE t.typname = :enum_name
+        ORDER BY e.enumsortorder
+        """
+    ).bindparams(enum_name=enum_name)
+
+    result = session.exec(statement)
+    return [row[0] for row in result]
+
+
+def make_add_enum_value_sql(enum_name: str, label: str) -> str:
+    """Return an ``ALTER TYPE`` statement to add ``label`` to ``enum_name``."""
+
+    quoted_enum = _PREPARER.format_type(enum_name)
+    literal_label = literal(label).compile(
+        dialect=_POSTGRES_DIALECT, compile_kwargs={"literal_binds": True}
+    )
+    return f"ALTER TYPE {quoted_enum} ADD VALUE IF NOT EXISTS {literal_label};"
+
+
+def load_enum_sync_state(session: Session, enum_name: str, enum: type[Enum]) -> EnumSyncState:
+    """Return the synchronisation state for ``enum_name``."""
+
+    expected = enum_labels(enum)
+    current = database_enum_labels(session, enum_name)
+    return EnumSyncState(name=enum_name, expected_labels=expected, database_labels=current)
+
+
+def build_sync_plan(
+    session: Session, enum_definitions: Mapping[str, type[Enum]]
+) -> list[EnumSyncState]:
+    """Return the sync states for all provided enum definitions."""
+
+    return [load_enum_sync_state(session, name, enum) for name, enum in enum_definitions.items()]
+
+
+def missing_statements(states: Iterable[EnumSyncState]) -> list[str]:
+    """Collect SQL statements for every enum state that is out of sync."""
+
+    statements: list[str] = []
+    for state in states:
+        statements.extend(state.statements)
+    return statements
+
+
+__all__ = [
+    "AUDIT_ENUM_DEFINITIONS",
+    "EnumSyncState",
+    "build_sync_plan",
+    "database_enum_labels",
+    "enum_labels",
+    "load_enum_sync_state",
+    "make_add_enum_value_sql",
+    "missing_statements",
+]

--- a/app/audit/schemas.py
+++ b/app/audit/schemas.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from app.config import timezone as env_timezone
 
 from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, Optional, Type
 from zoneinfo import ZoneInfo
-from typing import Any, Dict, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .taxonomy import AuditAction, AuditSeverity, AuditTargetType
 
@@ -21,9 +22,9 @@ def _utcnow() -> datetime:
 class AuditEventBase(BaseModel):
     """Shared attributes for audit payloads."""
 
-    action: AuditAction
-    severity: AuditSeverity = AuditSeverity.INFO
-    target_type: AuditTargetType
+    action: str
+    severity: str = Field(default=AuditSeverity.INFO.value)
+    target_type: str
     target_id: Optional[UUID] = None
     actor_id: Optional[UUID] = None
     request_id: Optional[str] = Field(default=None, max_length=64)
@@ -31,6 +32,78 @@ class AuditEventBase(BaseModel):
     request_metadata: Dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(use_enum_values=True)
+
+    @staticmethod
+    def _normalise_enum_literal(
+        raw: Any,
+        enum_cls: Type[Enum],
+    ) -> str | Any:
+        """Return the canonical enum value when *raw* matches *enum_cls*."""
+
+        if isinstance(raw, enum_cls):
+            return raw.value  # type: ignore[return-value]
+
+        if raw is None:
+            return raw
+
+        literal = str(raw).strip()
+        if not literal:
+            return literal
+
+        for member in enum_cls:  # type: ignore[assignment]
+            if literal == member.value:
+                return member.value
+
+        literal_fold = literal.casefold()
+        for member in enum_cls:  # type: ignore[assignment]
+            if literal_fold == member.value.casefold():
+                return member.value
+
+        literal_upper = literal.upper()
+        try:
+            return enum_cls[literal_upper].value  # type: ignore[index]
+        except KeyError:
+            pass
+
+        for member in enum_cls:  # type: ignore[assignment]
+            if literal_fold == member.name.lower():
+                return member.value
+
+        return literal
+
+    @field_validator("action", mode="before")
+    @classmethod
+    def _coerce_action(cls, raw: Any) -> Any:
+        return cls._normalise_enum_literal(raw, AuditAction)
+
+    @field_validator("severity", mode="before")
+    @classmethod
+    def _coerce_severity(cls, raw: Any) -> Any:
+        return cls._normalise_enum_literal(raw, AuditSeverity)
+
+    @field_validator("target_type", mode="before")
+    @classmethod
+    def _coerce_target_type(cls, raw: Any) -> Any:
+        return cls._normalise_enum_literal(raw, AuditTargetType)
+
+    @model_validator(mode="after")
+    def _revalidate_taxonomy(self) -> "AuditEventBase":
+        errors: list[str] = []
+
+        def _validate(member_cls: Type[Enum], value: Any, label: str) -> None:
+            try:
+                member_cls(value)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                errors.append(f"Unknown audit {label} literal: {value!r}")
+
+        _validate(AuditAction, self.action, "action")
+        _validate(AuditSeverity, self.severity, "severity")
+        _validate(AuditTargetType, self.target_type, "target_type")
+
+        if errors:
+            raise ValueError("; ".join(errors))
+
+        return self
 
 
 class AuditEventCreate(AuditEventBase):

--- a/app/migrations/versions/b62e0d8f5d9a_sync_audit_enums_with_taxonomy.py
+++ b/app/migrations/versions/b62e0d8f5d9a_sync_audit_enums_with_taxonomy.py
@@ -1,0 +1,30 @@
+"""ensure audit enums include taxonomy literals
+
+Revision ID: b62e0d8f5d9a
+Revises: 1a2b3c4d5e67
+Create Date: 2024-05-10 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from app.audit.enum_utils import AUDIT_ENUM_DEFINITIONS, enum_labels, make_add_enum_value_sql
+
+# revision identifiers, used by Alembic.
+revision: str = "b62e0d8f5d9a"
+down_revision: Union[str, None] = "1a2b3c4d5e67"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    for enum_name, enum in AUDIT_ENUM_DEFINITIONS.items():
+        for label in enum_labels(enum):
+            op.execute(make_add_enum_value_sql(enum_name, label))
+
+
+def downgrade() -> None:
+    # Values added to PostgreSQL enums cannot be removed without manual intervention.
+    pass

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for maintaining the application."""

--- a/scripts/sync_enums.py
+++ b/scripts/sync_enums.py
@@ -1,0 +1,54 @@
+"""CLI to synchronise PostgreSQL enums with the application taxonomy."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable
+
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.audit.enum_utils import AUDIT_ENUM_DEFINITIONS, build_sync_plan, missing_statements
+
+SessionFactory = Callable[[], Session]
+
+
+def main(argv: list[str] | None = None, session_factory_override: SessionFactory | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Ensure PostgreSQL enum types include every taxonomy literal.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Execute the ALTER TYPE statements instead of printing them.",
+    )
+    args = parser.parse_args(argv)
+
+    if session_factory_override is None:
+        from app.db.session import session_factory as session_factory_override
+
+    with session_factory_override() as session:
+        states = build_sync_plan(session, AUDIT_ENUM_DEFINITIONS)
+
+        statements = missing_statements(states)
+        if not statements:
+            print("All database enum types are synchronized with the application taxonomy.")
+            return 0
+
+        if not args.apply:
+            print("Missing enum values detected; run with --apply to execute the fixes.")
+            for statement in statements:
+                print(statement)
+            return 1
+
+        for statement in statements:
+            session.exec(text(statement))
+        session.commit()
+
+    print(f"Applied {len(statements)} ALTER TYPE statements.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    sys.exit(main())

--- a/scripts/validate_enum_sync.py
+++ b/scripts/validate_enum_sync.py
@@ -1,0 +1,54 @@
+"""CLI to validate that PostgreSQL enums match the application taxonomy."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable, Iterable
+
+from sqlmodel import Session
+
+from app.audit.enum_utils import AUDIT_ENUM_DEFINITIONS, EnumSyncState, build_sync_plan
+
+
+def _format_missing(states: Iterable[EnumSyncState]) -> str:
+    lines: list[str] = []
+    for state in states:
+        if not state.missing_labels:
+            continue
+        lines.append(f"- {state.name}: {', '.join(state.missing_labels)}")
+    return "\n".join(lines)
+
+
+SessionFactory = Callable[[], Session]
+
+
+def _run_validation(session_factory: SessionFactory) -> list[EnumSyncState]:
+    with session_factory() as session:
+        return build_sync_plan(session, AUDIT_ENUM_DEFINITIONS)
+
+
+def main(argv: list[str] | None = None, session_factory_override: SessionFactory | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate that PostgreSQL enum types include every taxonomy literal.",
+    )
+    parser.parse_args(argv)
+
+    if session_factory_override is None:
+        from app.db.session import session_factory as session_factory_override
+
+    states = _run_validation(session_factory_override)
+
+    missing = [state for state in states if state.missing_labels]
+    if not missing:
+        print("All database enum types are synchronized with the application taxonomy.")
+        return 0
+
+    print("Missing enum values detected:")
+    print(_format_missing(missing))
+    print("\nRun `python -m scripts.sync_enums --apply` to add the missing values.")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    sys.exit(main())

--- a/test/test_audit_pipeline.py
+++ b/test/test_audit_pipeline.py
@@ -77,3 +77,49 @@ def test_repository_persists_audit_events(tmp_path) -> None:
     assert stored.action == AuditAction.TOKEN_INVALID
     assert stored.severity == AuditSeverity.WARNING
     assert stored.target_type == AuditTargetType.AUTH_TOKEN
+
+
+def test_audit_event_persists_enum_variants(tmp_path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'audit_variants.db'}", echo=False)
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        event_from_enum = AuditEvent(
+            action=AuditAction.TOKEN_REVOKED,
+            severity=AuditSeverity.CRITICAL,
+            target_type=AuditTargetType.AUTH_TOKEN,
+        )
+        session.add(event_from_enum)
+        session.commit()
+
+        raw_event_from_enum = session.exec(
+            select(
+                AuditEvent.__table__.c.action,
+                AuditEvent.__table__.c.severity,
+                AuditEvent.__table__.c.target_type,
+            ).where(AuditEvent.__table__.c.audit_event_id == event_from_enum.id)
+        ).one()
+
+        assert raw_event_from_enum.action == AuditAction.TOKEN_REVOKED.value
+        assert raw_event_from_enum.severity == AuditSeverity.CRITICAL.value
+        assert raw_event_from_enum.target_type == AuditTargetType.AUTH_TOKEN.value
+
+        event_from_name = AuditEvent(
+            action=AuditAction.TOKEN_REVOKED.name,
+            severity=AuditSeverity.INFO.name,
+            target_type=AuditTargetType.AUTH_TOKEN.name,
+        )
+        session.add(event_from_name)
+        session.commit()
+
+        raw_event_from_name = session.exec(
+            select(
+                AuditEvent.__table__.c.action,
+                AuditEvent.__table__.c.severity,
+                AuditEvent.__table__.c.target_type,
+            ).where(AuditEvent.__table__.c.audit_event_id == event_from_name.id)
+        ).one()
+
+        assert raw_event_from_name.action == AuditAction.TOKEN_REVOKED.value
+        assert raw_event_from_name.severity == AuditSeverity.INFO.value
+        assert raw_event_from_name.target_type == AuditTargetType.AUTH_TOKEN.value

--- a/test/test_enum_sync.py
+++ b/test/test_enum_sync.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+
+import pytest
+from sqlalchemy import text
+from sqlmodel import Session, create_engine
+
+from app.audit.enum_utils import AUDIT_ENUM_DEFINITIONS, enum_labels
+
+
+@pytest.fixture()
+def fake_postgres():
+    engine = create_engine("sqlite://", future=True)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE pg_type (oid INTEGER PRIMARY KEY AUTOINCREMENT, typname TEXT NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE pg_enum (enumtypid INTEGER NOT NULL, enumlabel TEXT NOT NULL, "
+                "enumsortorder INTEGER NOT NULL)"
+            )
+        )
+
+        for oid, (enum_name, enum) in enumerate(AUDIT_ENUM_DEFINITIONS.items(), start=1):
+            conn.execute(
+                text("INSERT INTO pg_type (oid, typname) VALUES (:oid, :typname)"),
+                {"oid": oid, "typname": enum_name},
+            )
+            labels = enum_labels(enum)
+            if labels:
+                conn.execute(
+                    text(
+                        "INSERT INTO pg_enum (enumtypid, enumlabel, enumsortorder) "
+                        "VALUES (:enumtypid, :enumlabel, :enumsortorder)"
+                    ),
+                    {"enumtypid": oid, "enumlabel": labels[0], "enumsortorder": 1},
+                )
+    yield engine
+    engine.dispose()
+
+
+def _populate_missing(engine) -> None:
+    with engine.begin() as conn:
+        for oid, (enum_name, enum) in enumerate(AUDIT_ENUM_DEFINITIONS.items(), start=1):
+            labels = enum_labels(enum)
+            for index, label in enumerate(labels, start=1):
+                exists = conn.execute(
+                    text(
+                        "SELECT 1 FROM pg_enum WHERE enumtypid = :enumtypid AND enumlabel = :enumlabel"
+                    ),
+                    {"enumtypid": oid, "enumlabel": label},
+                ).first()
+                if exists is None:
+                    conn.execute(
+                        text(
+                            "INSERT INTO pg_enum (enumtypid, enumlabel, enumsortorder) "
+                            "VALUES (:enumtypid, :enumlabel, :enumsortorder)"
+                        ),
+                        {"enumtypid": oid, "enumlabel": label, "enumsortorder": index},
+                    )
+
+
+def test_validate_enum_sync_detects_and_resolves_missing_values(fake_postgres):
+    from scripts import validate_enum_sync
+
+    def _session_factory() -> Session:
+        return Session(fake_postgres)
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        exit_code = validate_enum_sync.main([], session_factory_override=_session_factory)
+    output = buffer.getvalue()
+
+    assert exit_code == 1
+    assert "Missing enum values detected" in output
+
+    _populate_missing(fake_postgres)
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        exit_code = validate_enum_sync.main([], session_factory_override=_session_factory)
+    output = buffer.getvalue()
+
+    assert exit_code == 0
+    assert "synchronized" in output.lower()


### PR DESCRIPTION
# Summary
- Normalize the audit schemas and model bindings so enums are always persisted and exposed via their canonical values.

- Add reusable enum-sync utilities and CLI entrypoints to detect and repair gaps between Python taxonomy and PostgreSQL types.

- Extend audit regression coverage to lock down enum coercion behaviour for schemas, services, and persistence.
