### PR TITLE
Refactor email templates to share base layout

### DIFF
--- a/app/core/interfaces/emails.py
+++ b/app/core/interfaces/emails.py
@@ -43,99 +43,169 @@ def send_email(to: str, subject: str, html_content: str, message: str):
     server.login(EMAIL_HOST_USER, EMAIL_HOST_PASSWORD)
     server.send_message(msg)
     server.quit()
-    
+
 class EmailService(BaseInterface):
     @staticmethod
-    def send_welcome_email(email: str, first_name: str, last_name: str):
+    def _render_email(template_name: str, subject: str, context: dict) -> str:
+        merged_context = {
+            "request": {},
+            "brand_name": "Hospital SDLG",
+            "brand_tagline": "Cuidando tu salud con excelencia",
+            "email_subject": subject,
+            "action_summary": subject,
+            **context,
+        }
+
+        return TEMPLATES.TemplateResponse(
+            parser_name(folders=["emails"], name=rf"{template_name}"), merged_context
+        ).body.decode("utf-8")
+
+    @staticmethod
+    def send_welcome_email(
+        email: str,
+        first_name: str,
+        last_name: str,
+        help_link: str | None = None,
+        contact_number: str | None = None,
+        contact_email: str | None = None,
+        action_summary: str | None = None,
+    ):
         subject = "Bienvenido a Hospital SDLG"
         context = {
             "first_name": first_name,
-            "last_name": last_name
+            "last_name": last_name,
+            "help_link": help_link,
+            "contact_number": contact_number,
+            "contact_email": contact_email,
+            "action_summary": action_summary or "Bienvenido a Hospital SDLG",
         }
-        html_content = TEMPLATES.TemplateResponse(
-            parser_name(folders=["emails"], name=r"welcome_email"), {"request": {}, **context}
-        ).body.decode("utf-8")
-        
+        html_content = EmailService._render_email("welcome_email", subject, context)
+
         send_email(email, subject, html_content, None)
-    
+
     @staticmethod
-    def send_password_reset_email(email: str, reset_code: str):
+    def send_password_reset_email(
+        email: str,
+        reset_code: str,
+        help_link: str | None = None,
+        contact_number: str | None = None,
+        contact_email: str | None = None,
+        action_summary: str | None = None,
+    ):
         subject = "Restablecimiento de contraseña"
         context = {
-            "reset_code": reset_code
+            "reset_code": reset_code,
+            "help_link": help_link,
+            "contact_number": contact_number,
+            "contact_email": contact_email,
+            "action_summary": action_summary or "Restablecimiento de contraseña",
         }
-        html_content = TEMPLATES.TemplateResponse(
-            parser_name(folders=["emails"], name=r"password_reset_email"), {"request": {}, **context}
-        ).body.decode("utf-8")
-        
+        html_content = EmailService._render_email("password_reset_email", subject, context)
+
         send_email(email, subject, html_content, None)
-        
+
     @staticmethod
-    def send_password_changed_notification_email(email: str, help_link: str, contact_number: str, contact_email: str):
+    def send_password_changed_notification_email(
+        email: str,
+        help_link: str,
+        contact_number: str,
+        contact_email: str,
+        action_summary: str | None = None,
+    ):
         subject = "Notificación de cambio de contraseña"
         context = {
             "help_link": help_link,
             "contact_number": contact_number,
-            "contact_email": contact_email
+            "contact_email": contact_email,
+            "action_summary": action_summary or "Cambio de contraseña",
         }
-        html_content = TEMPLATES.TemplateResponse(
-            parser_name(folders=["emails"], name=r"password_changed_notification_email"), {"request": {}, **context}
-        ).body.decode("utf-8")
-        
+        html_content = EmailService._render_email("password_changed_notification_email", subject, context)
+
         send_email(email, subject, html_content, None)
-        
+
     @staticmethod
-    def send_verification_email(email: str, verification_code: str):
+    def send_verification_email(
+        email: str,
+        verification_code: str,
+        help_link: str | None = None,
+        contact_number: str | None = None,
+        contact_email: str | None = None,
+        action_summary: str | None = None,
+    ):
         subject = "Verificación de correo electrónico"
         context = {
-            "verification_code": verification_code
+            "verification_code": verification_code,
+            "help_link": help_link,
+            "contact_number": contact_number,
+            "contact_email": contact_email,
+            "action_summary": action_summary or "Verificación de correo electrónico",
         }
-        html_content = TEMPLATES.TemplateResponse(
-            parser_name(folders=["emails"], name=r"verification_email"), {"request": {}, **context}
-        ).body.decode("utf-8")
-        
+        html_content = EmailService._render_email("verification_email", subject, context)
+
         send_email(email, subject, html_content, None)
-        
+
     @staticmethod
     def send_update_data_notification_email(email, first_name: str, last_name: str, data_to_update: dict):
         subject = "Actualización de datos"
         context = {
             "first_name": first_name,
             "last_name": last_name,
-            "data_to_update": data_to_update # Nombre de el campo y el porque
+            "data_to_update": data_to_update, # Nombre de el campo y el porque
+            "action_summary": "Actualización de información",
         }
-        html_content = TEMPLATES.TemplateResponse(
-            parser_name(folders=["emails"], name=r"update_data_notification_email"), {"request": {}, **context}
-        ).body.decode("utf-8")
-        
+        html_content = EmailService._render_email("update_data_notification_email", subject, context)
+
         send_email(email, subject, html_content, None)
-        
+
     @staticmethod
-    def send_google_account_linked_password(email: str, first_name: str, last_name: str, raw_password: str):
+    def send_google_account_linked_password(
+        email: str,
+        first_name: str,
+        last_name: str,
+        raw_password: str,
+        help_link: str | None = None,
+        contact_number: str | None = None,
+        contact_email: str | None = None,
+        action_summary: str | None = None,
+    ):
         subject = "Cuenta de Google vinculada"
         context = {
             "first_name": first_name,
             "last_name": last_name,
-            "provisional_password": raw_password
+            "provisional_password": raw_password,
+            "help_link": help_link,
+            "contact_number": contact_number,
+            "contact_email": contact_email,
+            "action_summary": action_summary or "Cuenta de Google vinculada",
         }
-        html_content = TEMPLATES.TemplateResponse(
-            parser_name(folders=["emails"], name=r"google_account_linked_email"), {"request": {}, **context}
-        ).body.decode("utf-8")
-        
+        html_content = EmailService._render_email("google_account_linked_email", subject, context)
+
         send_email(email, subject, html_content, None)
 
     @staticmethod
-    def send_warning_google_account(email: str, first_name: str, last_name: str, created: datetime, to_delete: datetime):
+    def send_warning_google_account(
+        email: str,
+        first_name: str,
+        last_name: str,
+        created: datetime,
+        to_delete: datetime,
+        help_link: str | None = None,
+        contact_number: str | None = None,
+        contact_email: str | None = None,
+        action_summary: str | None = None,
+    ):
         days = to_delete - created
 
         subject = "Cuenta de Google vinculada"
         context = {
             "first_name": first_name,
             "last_name": last_name,
-            "days": days
+            "days": days,
+            "help_link": help_link,
+            "contact_number": contact_number,
+            "contact_email": contact_email,
+            "action_summary": action_summary or "Advertencia de cuenta",
         }
-        html_content = TEMPLATES.TemplateResponse(
-            parser_name(folders=["emails"], name=r"warning_google_account_email"), {"request": {}, **context}
-        ).body.decode("utf-8")
+        html_content = EmailService._render_email("warning_google_account_email", subject, context)
 
         send_email(email, subject, html_content, None)

--- a/app/templates/emails/base_email.html
+++ b/app/templates/emails/base_email.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ email_subject or brand_name or "Hospital SDLG" }}</title>
+    <style>
+        :root {
+            color-scheme: light;
+        }
+
+        body.email-body {
+            margin: 0;
+            padding: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background-color: #f8fafc;
+            line-height: 1.6;
+            color: #0f172a;
+        }
+
+        .email-container {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .outer-padding {
+            padding: 40px 20px;
+        }
+
+        .card {
+            width: 100%;
+            max-width: 640px;
+            margin: 0 auto;
+            background-color: #ffffff;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+            overflow: hidden;
+        }
+
+        .header {
+            text-align: center;
+            color: #ffffff;
+            padding: 32px 30px;
+        }
+
+        .brand {
+            margin: 0;
+            font-size: 26px;
+            font-weight: 800;
+            letter-spacing: -0.5px;
+        }
+
+        .brand-logo {
+            height: 42px;
+        }
+
+        .header-subtitle {
+            margin: 6px 0 0 0;
+            color: rgba(255, 255, 255, 0.9);
+            font-size: 15px;
+            font-weight: 600;
+        }
+
+        .content {
+            padding: 36px 30px;
+            background-color: #ffffff;
+        }
+
+        .title {
+            margin: 0 0 14px 0;
+            color: #0f172a;
+            font-size: 24px;
+            font-weight: 800;
+            letter-spacing: -0.4px;
+        }
+
+        .subtitle {
+            margin: 0 0 10px 0;
+            color: #1e293b;
+            font-size: 18px;
+            font-weight: 700;
+        }
+
+        .text {
+            margin: 0 0 16px 0;
+            color: #334155;
+            font-size: 15px;
+            line-height: 1.6;
+        }
+
+        .muted {
+            color: #64748b;
+            font-size: 14px;
+        }
+
+        .icon-circle {
+            width: 64px;
+            height: 64px;
+            border-radius: 50%;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 16px;
+        }
+
+        .icon-circle.info { background-color: #e0f2fe; color: #1d4ed8; }
+        .icon-circle.success { background-color: #dcfce7; color: #15803d; }
+        .icon-circle.warning { background-color: #fef3c7; color: #b45309; }
+        .icon-circle.danger { background-color: #fee2e2; color: #b91c1c; }
+
+        .cta-button {
+            display: inline-block;
+            background: linear-gradient(135deg, #1d4ed8 0%, #2563eb 50%, #1d4ed8 100%);
+            color: #ffffff;
+            padding: 12px 22px;
+            border-radius: 12px;
+            text-decoration: none;
+            font-weight: 700;
+            letter-spacing: -0.2px;
+            box-shadow: 0 10px 25px rgba(37, 99, 235, 0.25);
+        }
+
+        .panel {
+            border-radius: 12px;
+            padding: 18px 20px;
+            border: 1px solid #e2e8f0;
+            background: #f8fafc;
+            margin: 22px 0;
+        }
+
+        .panel--info { background: #eff6ff; border-color: #bfdbfe; }
+        .panel--accent { background: #eef2ff; border-color: #c7d2fe; }
+        .panel--success { background: #ecfdf3; border-color: #a7f3d0; }
+        .panel--warning { background: #fff7ed; border-color: #fcd34d; }
+        .panel--danger { background: #fef2f2; border-color: #fecaca; }
+
+        .code-badge {
+            display: inline-block;
+            padding: 14px 18px;
+            border-radius: 12px;
+            background: #ffffff;
+            border: 2px solid #1d4ed8;
+            font-family: "Courier New", monospace;
+            font-size: 28px;
+            font-weight: 800;
+            letter-spacing: 4px;
+            color: #0f172a;
+        }
+
+        .list {
+            margin: 0;
+            padding-left: 18px;
+            color: #334155;
+        }
+
+        .list li {
+            margin-bottom: 10px;
+            line-height: 1.5;
+        }
+
+        .info-grid {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        .info-item {
+            padding: 12px 0;
+            border-bottom: 1px solid #e2e8f0;
+        }
+
+        .info-label {
+            margin: 0;
+            color: #1f2937;
+            font-weight: 700;
+            font-size: 14px;
+        }
+
+        .info-value {
+            margin: 4px 0 0 0;
+            color: #475569;
+            font-size: 13px;
+        }
+
+        .footer {
+            background-color: #f9fafb;
+            padding: 26px 24px;
+            text-align: center;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .footer-title {
+            margin: 0 0 8px 0;
+            color: #475569;
+            font-weight: 700;
+        }
+
+        .footer-link {
+            color: #2563eb;
+            text-decoration: none;
+            font-weight: 700;
+        }
+
+        .footer-contact {
+            margin: 4px 0;
+            color: #475569;
+            font-size: 14px;
+        }
+
+        .footer-note {
+            margin: 12px 0 0 0;
+            color: #94a3b8;
+            font-size: 12px;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 8px 12px;
+            border-radius: 999px;
+            background: #e2e8f0;
+            color: #0f172a;
+            font-size: 13px;
+            font-weight: 700;
+        }
+    </style>
+</head>
+<body class="email-body">
+<table role="presentation" class="email-container">
+    <tr>
+        <td class="outer-padding">
+            <table role="presentation" class="card">
+                <tr>
+                    <td class="header" style="{% block header_background %}background: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%);{% endblock %}">
+                        <div class="logo">
+                            {% if logo_url %}
+                                <img src="{{ logo_url }}" alt="{{ brand_name or 'Hospital SDLG' }}" class="brand-logo" />
+                            {% else %}
+                                <p class="brand">{{ brand_name or 'Hospital SDLG' }}</p>
+                            {% endif %}
+                        </div>
+                        <p class="header-subtitle">
+                            {% block header_subtitle %}{{ action_summary or brand_tagline or 'Cuidando tu salud con excelencia' }}{% endblock %}
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="content">
+                        {% block body %}{% endblock %}
+                    </td>
+                </tr>
+                <tr>
+                    <td class="footer">
+                        <p class="footer-title">¿Necesitas ayuda?</p>
+                        {% if help_link %}
+                            <p class="footer-contact"><a class="footer-link" href="{{ help_link }}">Centro de ayuda</a></p>
+                        {% endif %}
+                        {% if contact_email or contact_number %}
+                            <p class="footer-contact">
+                                {% if contact_email %}<a class="footer-link" href="mailto:{{ contact_email }}">{{ contact_email }}</a>{% endif %}
+                                {% if contact_email and contact_number %} · {% endif %}
+                                {% if contact_number %}<a class="footer-link" href="tel:{{ contact_number }}">{{ contact_number }}</a>{% endif %}
+                            </p>
+                        {% endif %}
+                        <p class="footer-note">{{ support_note or 'Este correo fue enviado automáticamente. Por favor, no respondas a este mensaje.' }}</p>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/app/templates/emails/google_account_linked_email.html
+++ b/app/templates/emails/google_account_linked_email.html
@@ -1,127 +1,48 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cuenta de Google vinculada</title>
-</head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; background-color: #f8fafc; line-height: 1.6;">
-    <table role="presentation" style="width: 100%; border-collapse: collapse; margin: 0; padding: 0;">
-        <tr>
-            <td style="padding: 40px 20px;">
-                <table role="presentation" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); overflow: hidden;">
-                    <!-- Header -->
-                    <tr>
-                        <td style="background: linear-gradient(135deg, #ea4335 0%, #4285f4 50%, #34a853 100%); padding: 40px 30px; text-align: center;">
-                            <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px;">
-                                Hospital SDLG
-                            </h1>
-                            <p style="margin: 8px 0 0 0; color: #ffffff; font-size: 16px; font-weight: 400; opacity: 0.9;">
-                                Cuenta de Google vinculada exitosamente
-                            </p>
-                        </td>
-                    </tr>
-                    
-                    <!-- Content -->
-                    <tr>
-                        <td style="padding: 40px 30px;">
-                            <div style="text-align: center; margin-bottom: 30px;">
-                                <div style="display: inline-block; width: 60px; height: 60px; background-color: #e8f5e8; border-radius: 50%; position: relative;">
-                                    <span style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 24px;">🔗</span>
-                                </div>
-                            </div>
-                            
-                            <h2 style="margin: 0 0 20px 0; color: #1f2937; font-size: 24px; font-weight: 600; text-align: center;">
-                                ¡Hola {{ first_name }} {{ last_name }}!
-                            </h2>
-                            
-                            <p style="margin: 0 0 24px 0; color: #4b5563; font-size: 16px; line-height: 1.6; text-align: center;">
-                                Tu cuenta de Google ha sido vinculada exitosamente con Hospital SDLG. Hemos generado una contraseña provisional para que puedas acceder a tu cuenta.
-                            </p>
-                            
-                            <!-- Contraseña provisional destacada -->
-                            <div style="background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); border: 2px solid #f59e0b; border-radius: 8px; padding: 24px; margin: 24px 0; text-align: center;">
-                                <p style="margin: 0 0 12px 0; color: #92400e; font-size: 16px; font-weight: 600;">
-                                    Tu contraseña provisional:
-                                </p>
-                                <div style="background-color: #ffffff; border: 2px dashed #f59e0b; border-radius: 6px; padding: 20px; margin: 12px 0;">
-                                    <span style="font-family: 'Courier New', monospace; font-size: 24px; font-weight: 700; color: #1f2937; letter-spacing: 2px;">
-                                        {{ provisional_password }}
-                                    </span>
-                                </div>
-                                <p style="margin: 12px 0 0 0; color: #92400e; font-size: 13px; font-weight: 500;">
-                                    ⚠️ Cambia esta contraseña en tu primer inicio de sesión
-                                </p>
-                            </div>
-                            
-                            <!-- Instrucciones paso a paso -->
-                            <div style="background-color: #f0f9ff; border-left: 4px solid #3b82f6; padding: 20px; margin: 24px 0; border-radius: 0 6px 6px 0;">
-                                <h3 style="margin: 0 0 16px 0; color: #1e40af; font-size: 18px; font-weight: 600;">
-                                    Próximos pasos:
-                                </h3>
-                                <ol style="margin: 0; padding-left: 20px; color: #374151;">
-                                    <li style="margin-bottom: 8px; line-height: 1.5;">
-                                        <strong>Inicia sesión</strong> con tu email y la contraseña provisional
-                                    </li>
-                                    <li style="margin-bottom: 8px; line-height: 1.5;">
-                                        <strong>Cambia tu contraseña</strong> por una más segura y personal
-                                    </li>
-                                    <li style="margin-bottom: 0; line-height: 1.5;">
-                                        <strong>Explora</strong> todos los servicios médicos disponibles
-                                    </li>
-                                </ol>
-                            </div>
-                            
-                            <!-- Información de seguridad -->
-                            <div style="background-color: #fef2f2; border: 1px solid #fecaca; border-radius: 6px; padding: 16px; margin: 24px 0;">
-                                <div style="display: flex; align-items: flex-start;">
-                                    <span style="color: #dc2626; font-size: 18px; margin-right: 12px; flex-shrink: 0;">🛡️</span>
-                                    <div>
-                                        <h4 style="margin: 0 0 8px 0; color: #991b1b; font-size: 16px; font-weight: 600;">
-                                            Importante para tu seguridad:
-                                        </h4>
-                                        <ul style="margin: 0; padding-left: 16px; color: #7f1d1d; font-size: 14px;">
-                                            <li style="margin-bottom: 4px;">Esta contraseña es temporal y debe cambiarse</li>
-                                            <li style="margin-bottom: 4px;">No compartas esta información con nadie</li>
-                                            <li style="margin-bottom: 0;">Si no solicitaste esta vinculación, contacta soporte inmediatamente</li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <!-- Beneficios de la vinculación -->
-                            <div style="background-color: #ecfdf5; border-left: 4px solid #10b981; padding: 20px; margin: 24px 0; border-radius: 0 6px 6px 0;">
-                                <h3 style="margin: 0 0 12px 0; color: #065f46; font-size: 16px; font-weight: 600;">
-                                    ✅ Beneficios de tu cuenta vinculada:
-                                </h3>
-                                <ul style="margin: 0; padding-left: 20px; color: #047857; font-size: 14px;">
-                                    <li style="margin-bottom: 6px;">Acceso rápido con tu cuenta de Google</li>
-                                    <li style="margin-bottom: 6px;">Sincronización automática de datos básicos</li>
-                                    <li style="margin-bottom: 6px;">Mayor seguridad en tu cuenta médica</li>
-                                    <li style="margin-bottom: 0;">Experiencia de usuario mejorada</li>
-                                </ul>
-                            </div>
-                            
-                            <p style="margin: 24px 0 0 0; color: #6b7280; font-size: 14px; text-align: center;">
-                                Si necesitas ayuda con el proceso de cambio de contraseña, nuestro equipo de soporte está disponible 24/7.
-                            </p>
-                        </td>
-                    </tr>
-                    
-                    <!-- Footer -->
-                    <tr>
-                        <td style="background-color: #f9fafb; padding: 30px; text-align: center; border-top: 1px solid #e5e7eb;">
-                            <p style="margin: 0 0 12px 0; color: #6b7280; font-size: 14px;">
-                                Hospital SDLG - Innovación y seguridad en salud digital
-                            </p>
-                            <p style="margin: 0; color: #9ca3af; font-size: 12px;">
-                                Este correo contiene información confidencial. Por favor, no respondas a este mensaje.
-                            </p>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
-</body>
-</html>
+{% extends "emails/base_email.html" %}
+
+{% block header_background %}background: linear-gradient(135deg, #ea4335 0%, #4285f4 50%, #34a853 100%);{% endblock %}
+{% block header_subtitle %}{{ action_summary or "Cuenta de Google vinculada" }}{% endblock %}
+
+{% block body %}
+<div style="text-align: center;">
+    <div class="icon-circle success" style="background: #e8f5e8; color: #166534;">🔗</div>
+</div>
+
+<h2 class="title" style="text-align: center;">¡Hola {{ first_name }} {{ last_name }}!</h2>
+<p class="text" style="text-align: center;">
+    Tu cuenta de Google ha sido vinculada exitosamente con Hospital SDLG. Hemos generado una contraseña provisional para que puedas acceder a tu cuenta.
+</p>
+
+<div class="panel panel--warning" style="text-align: center; border-color: #f59e0b; background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);">
+    <p class="subtitle" style="margin-bottom: 12px; color: #92400e;">Tu contraseña provisional:</p>
+    <div class="code-badge" style="border-color: #f59e0b;">{{ provisional_password }}</div>
+    <p class="muted" style="margin-top: 12px; color: #92400e;">⚠️ Cambia esta contraseña en tu primer inicio de sesión</p>
+</div>
+
+<div class="panel panel--info">
+    <h3 class="subtitle">Próximos pasos:</h3>
+    <ol class="list">
+        <li><strong>Inicia sesión</strong> con tu email y la contraseña provisional.</li>
+        <li><strong>Cambia tu contraseña</strong> por una más segura y personal.</li>
+        <li><strong>Explora</strong> todos los servicios médicos disponibles.</li>
+    </ol>
+</div>
+
+<div class="panel panel--danger">
+    <p class="text" style="margin: 0;">
+        <strong>Importante:</strong> Esta contraseña es temporal y debe cambiarse. No compartas esta información y, si no solicitaste esta vinculación, contacta soporte inmediatamente.
+    </p>
+</div>
+
+<div class="panel panel--success">
+    <h3 class="subtitle">Beneficios de tu cuenta vinculada:</h3>
+    <ul class="list">
+        <li>Acceso rápido con tu cuenta de Google</li>
+        <li>Sincronización automática de datos básicos</li>
+        <li>Mayor seguridad en tu cuenta médica</li>
+        <li>Experiencia de usuario mejorada</li>
+    </ul>
+</div>
+
+<p class="muted" style="text-align: center;">Si necesitas ayuda con el proceso de cambio de contraseña, nuestro equipo de soporte está disponible 24/7.</p>
+{% endblock %}

--- a/app/templates/emails/password_changed_notification_email.html
+++ b/app/templates/emails/password_changed_notification_email.html
@@ -1,80 +1,35 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Se restablecio su contraseña</title>
-</head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; background-color: #f8fafc; line-height: 1.6;">
-    <table role="presentation" style="width: 100%; border-collapse: collapse; margin: 0; padding: 0;">
-        <tr>
-            <td style="padding: 40px 20px;">
-                <table role="presentation" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); overflow: hidden;">
-                    <!-- Header -->
-                    <tr>
-                        <td style="background: linear-gradient(135deg, #dc2626 0%, #ef4444 100%); padding: 40px 30px; text-align: center;">
-                            <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px;">
-                                Hospital SDLG
-                            </h1>
-                            <p style="margin: 8px 0 0 0; color: #fecaca; font-size: 16px; font-weight: 400;">
-                                Se restablecio su contraseña
-                            </p>
-                        </td>
-                    </tr>
-                    
-                    <!-- Content -->
-                    <tr>
-                        <td style="padding: 40px 30px;">
-                            <div style="text-align: center; margin-bottom: 30px;">
-                                <div style="display: inline-block; width: 60px; height: 60px; background-color: #fee2e2; border-radius: 50%; position: relative;">
-                                    <span style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 24px; color: #dc2626;">🔒</span>
-                                </div>
-                            </div>
-                            
-                            <h2 style="margin: 0 0 20px 0; color: #1f2937; font-size: 24px; font-weight: 600; text-align: center;">
-                                Mensaje de advertencia
-                            </h2>
-                            
-                            <p style="margin: 0 0 24px 0; color: #4b5563; font-size: 16px; line-height: 1.6; text-align: center;">
-                                Hemos cambiado su contraseña por una solicitud desde tu cuenta en Hospital SDLG por cualquier inconveniente contacte al servicio tecnico del Hospital SDLG.
-                            </p>
-                            
-                            <div style="background-color: #fef3c7; border: 1px solid #f59e0b; border-radius: 6px; padding: 20px; margin: 24px 0; text-align: center;">
-                                <p style="margin: 0 0 12px 0; color: #92400e; font-size: 14px; font-weight: 600;">
-                                    Link de ayuda:
-                                </p>
-                                <div style="background-color: #ffffff; border: 2px solid #f59e0b; border-radius: 8px; padding: 16px; margin: 12px 0;">
-                                    <span style="font-family: 'Courier New', monospace; font-size: 32px; font-weight: 700; color: #1f2937; letter-spacing: 4px;">
-                                        {{ help_link }}
-                                    </span>
-                                </div>
-                                <p style="margin: 12px 0 0 0; color: #92400e; font-size: 12px;">
-                                    o contacte al numero/email: <a href="">{{contact_number}}</a> / <a href="mailto:{{contact_email}}">{{contact_email}}</a>
-                                </p>
-                            </div>
-                            
-                            <div style="background-color: #fef2f2; border-left: 4px solid #ef4444; padding: 16px; margin: 24px 0; border-radius: 0 4px 4px 0;">
-                                <p style="margin: 0; color: #991b1b; font-size: 14px; font-weight: 500;">
-                                    <strong>Importante:</strong> Si no solicitaste este restablecimiento, comunicate con el servicio. Tu cuenta sera recuperada segura.
-                                </p>
-                            </div>
-                        </td>
-                    </tr>
-                    
-                    <!-- Footer -->
-                    <tr>
-                        <td style="background-color: #f9fafb; padding: 30px; text-align: center; border-top: 1px solid #e5e7eb;">
-                            <p style="margin: 0 0 12px 0; color: #6b7280; font-size: 14px;">
-                                Hospital SDLG - Protegiendo tu información médica
-                            </p>
-                            <p style="margin: 0; color: #9ca3af; font-size: 12px;">
-                                Este correo fue enviado automáticamente. Por favor, no respondas a este mensaje.
-                            </p>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
-</body>
-</html>
+{% extends "emails/base_email.html" %}
+
+{% block header_background %}background: linear-gradient(135deg, #dc2626 0%, #ef4444 100%);{% endblock %}
+{% block header_subtitle %}{{ action_summary or "Cambio de contraseña" }}{% endblock %}
+
+{% block body %}
+<div style="text-align: center;">
+    <div class="icon-circle danger">🔒</div>
+</div>
+
+<h2 class="title" style="text-align: center;">Mensaje de advertencia</h2>
+<p class="text" style="text-align: center;">
+    Hemos cambiado tu contraseña por una solicitud desde tu cuenta en Hospital SDLG. Si necesitas ayuda adicional, contáctanos.
+</p>
+
+<div class="panel panel--warning" style="text-align: center;">
+    <p class="subtitle" style="margin-bottom: 12px;">Link de ayuda:</p>
+    {% if help_link %}
+        <p class="text" style="margin: 0 0 14px 0;"><a class="cta-button" href="{{ help_link }}">Revisar ayuda</a></p>
+    {% else %}
+        <p class="muted" style="margin: 0 0 14px 0;">Comunícate con soporte para obtener ayuda.</p>
+    {% endif %}
+    <p class="muted" style="margin: 0;">
+        {% if contact_number %}Teléfono: <a href="tel:{{ contact_number }}">{{ contact_number }}</a>{% endif %}
+        {% if contact_number and contact_email %} · {% endif %}
+        {% if contact_email %}Email: <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>{% endif %}
+    </p>
+</div>
+
+<div class="panel panel--danger">
+    <p class="text" style="margin: 0;">
+        <strong>Importante:</strong> Si no solicitaste este restablecimiento, comunícate con el servicio técnico. Tu cuenta será recuperada y protegida.
+    </p>
+</div>
+{% endblock %}

--- a/app/templates/emails/password_reset_email.html
+++ b/app/templates/emails/password_reset_email.html
@@ -1,84 +1,29 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Restablecimiento de contraseña</title>
-</head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; background-color: #f8fafc; line-height: 1.6;">
-    <table role="presentation" style="width: 100%; border-collapse: collapse; margin: 0; padding: 0;">
-        <tr>
-            <td style="padding: 40px 20px;">
-                <table role="presentation" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); overflow: hidden;">
-                    <!-- Header -->
-                    <tr>
-                        <td style="background: linear-gradient(135deg, #dc2626 0%, #ef4444 100%); padding: 40px 30px; text-align: center;">
-                            <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px;">
-                                Hospital SDLG
-                            </h1>
-                            <p style="margin: 8px 0 0 0; color: #fecaca; font-size: 16px; font-weight: 400;">
-                                Restablecimiento de contraseña
-                            </p>
-                        </td>
-                    </tr>
-                    
-                    <!-- Content -->
-                    <tr>
-                        <td style="padding: 40px 30px;">
-                            <div style="text-align: center; margin-bottom: 30px;">
-                                <div style="display: inline-block; width: 60px; height: 60px; background-color: #fee2e2; border-radius: 50%; position: relative;">
-                                    <span style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 24px; color: #dc2626;">🔒</span>
-                                </div>
-                            </div>
-                            
-                            <h2 style="margin: 0 0 20px 0; color: #1f2937; font-size: 24px; font-weight: 600; text-align: center;">
-                                Solicitud de restablecimiento
-                            </h2>
-                            
-                            <p style="margin: 0 0 24px 0; color: #4b5563; font-size: 16px; line-height: 1.6; text-align: center;">
-                                Hemos recibido una solicitud para restablecer la contraseña de tu cuenta en Hospital SDLG.
-                            </p>
-                            
-                            <div style="background-color: #fef3c7; border: 1px solid #f59e0b; border-radius: 6px; padding: 20px; margin: 24px 0; text-align: center;">
-                                <p style="margin: 0 0 12px 0; color: #92400e; font-size: 14px; font-weight: 600;">
-                                    Tu código de restablecimiento:
-                                </p>
-                                <div style="background-color: #ffffff; border: 2px solid #f59e0b; border-radius: 8px; padding: 16px; margin: 12px 0;">
-                                    <span style="font-family: 'Courier New', monospace; font-size: 32px; font-weight: 700; color: #1f2937; letter-spacing: 4px;">
-                                        {{ reset_code }}
-                                    </span>
-                                </div>
-                                <p style="margin: 12px 0 0 0; color: #92400e; font-size: 12px;">
-                                    Este código expira en 1 minuto
-                                </p>
-                            </div>
-                            
-                            <div style="background-color: #fef2f2; border-left: 4px solid #ef4444; padding: 16px; margin: 24px 0; border-radius: 0 4px 4px 0;">
-                                <p style="margin: 0; color: #991b1b; font-size: 14px; font-weight: 500;">
-                                    <strong>Importante:</strong> Si no solicitaste este restablecimiento, ignora este correo. Tu cuenta permanecerá segura.
-                                </p>
-                            </div>
-                            
-                            <p style="margin: 24px 0 0 0; color: #6b7280; font-size: 14px; text-align: center;">
-                                Por tu seguridad, nunca compartas este código con nadie.
-                            </p>
-                        </td>
-                    </tr>
-                    
-                    <!-- Footer -->
-                    <tr>
-                        <td style="background-color: #f9fafb; padding: 30px; text-align: center; border-top: 1px solid #e5e7eb;">
-                            <p style="margin: 0 0 12px 0; color: #6b7280; font-size: 14px;">
-                                Hospital SDLG - Protegiendo tu información médica
-                            </p>
-                            <p style="margin: 0; color: #9ca3af; font-size: 12px;">
-                                Este correo fue enviado automáticamente. Por favor, no respondas a este mensaje.
-                            </p>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
-</body>
-</html>
+{% extends "emails/base_email.html" %}
+
+{% block header_background %}background: linear-gradient(135deg, #dc2626 0%, #ef4444 100%);{% endblock %}
+{% block header_subtitle %}{{ action_summary or "Restablecimiento de contraseña" }}{% endblock %}
+
+{% block body %}
+<div style="text-align: center;">
+    <div class="icon-circle danger">🔒</div>
+</div>
+
+<h2 class="title" style="text-align: center;">Solicitud de restablecimiento</h2>
+<p class="text" style="text-align: center;">
+    Hemos recibido una solicitud para restablecer la contraseña de tu cuenta en Hospital SDLG.
+</p>
+
+<div class="panel panel--warning" style="text-align: center;">
+    <p class="subtitle" style="margin-bottom: 12px;">Tu código de restablecimiento:</p>
+    <div class="code-badge">{{ reset_code }}</div>
+    <p class="muted" style="margin-top: 12px;">Este código expira en 1 minuto</p>
+</div>
+
+<div class="panel panel--danger">
+    <p class="text" style="margin: 0;">
+        <strong>Importante:</strong> Si no solicitaste este restablecimiento, ignora este correo. Tu cuenta permanecerá segura.
+    </p>
+</div>
+
+<p class="muted" style="text-align: center;">Por tu seguridad, nunca compartas este código con nadie.</p>
+{% endblock %}

--- a/app/templates/emails/update_data_notification_email.html
+++ b/app/templates/emails/update_data_notification_email.html
@@ -1,98 +1,44 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Actualización de datos</title>
-</head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; background-color: #f8fafc; line-height: 1.6;">
-    <table role="presentation" style="width: 100%; border-collapse: collapse; margin: 0; padding: 0;">
-        <tr>
-            <td style="padding: 40px 20px;">
-                <table role="presentation" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); overflow: hidden;">
-                    <!-- Header -->
-                    <tr>
-                        <td style="background: linear-gradient(135deg, #7c3aed 0%, #8b5cf6 100%); padding: 40px 30px; text-align: center;">
-                            <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px;">
-                                Hospital SDLG
-                            </h1>
-                            <p style="margin: 8px 0 0 0; color: #ddd6fe; font-size: 16px; font-weight: 400;">
-                                Actualización de información
-                            </p>
-                        </td>
-                    </tr>
-                    
-                    <!-- Content -->
-                    <tr>
-                        <td style="padding: 40px 30px;">
-                            <div style="text-align: center; margin-bottom: 30px;">
-                                <div style="display: inline-block; width: 60px; height: 60px; background-color: #ede9fe; border-radius: 50%; position: relative;">
-                                    <span style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 24px; color: #7c3aed;">📝</span>
-                                </div>
-                            </div>
-                            
-                            <h2 style="margin: 0 0 20px 0; color: #1f2937; font-size: 24px; font-weight: 600; text-align: center;">
-                                Actualización de datos
-                            </h2>
-                            
-                            <p style="margin: 0 0 24px 0; color: #4b5563; font-size: 16px; line-height: 1.6;">
-                                Estimado/a {{ first_name }} {{ last_name }},
-                            </p>
-                            
-                            <p style="margin: 0 0 24px 0; color: #4b5563; font-size: 16px; line-height: 1.6;">
-                                Te informamos que se han actualizado algunos datos en tu perfil de Hospital SDLG. A continuación, encontrarás el detalle de los cambios realizados:
-                            </p>
-                            
-                            <div style="background-color: #faf5ff; border: 1px solid #8b5cf6; border-radius: 6px; padding: 20px; margin: 24px 0;">
-                                <h3 style="margin: 0 0 16px 0; color: #6b21a8; font-size: 18px; font-weight: 600;">
-                                    Datos actualizados:
-                                </h3>
-                                <div style="background-color: #ffffff; border-radius: 4px; padding: 16px;">
-                                    {% for field, reason in data_to_update.items() %}
-                                    <div style="margin-bottom: 12px; padding-bottom: 12px; border-bottom: 1px solid #e5e7eb;">
-                                        <p style="margin: 0 0 4px 0; color: #374151; font-size: 14px; font-weight: 600;">
-                                            {{ field }}
-                                        </p>
-                                        <p style="margin: 0; color: #6b7280; font-size: 13px;">
-                                            Motivo: {{ reason }}
-                                        </p>
-                                    </div>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                            
-                            <div style="background-color: #fef3c7; border-left: 4px solid #f59e0b; padding: 16px; margin: 24px 0; border-radius: 0 4px 4px 0;">
-                                <p style="margin: 0; color: #92400e; font-size: 14px;">
-                                    <strong>Importante:</strong> Si no reconoces estos cambios o crees que se trata de un error, contacta inmediatamente con nuestro equipo de soporte.
-                                </p>
-                            </div>
-                            
-                            <div style="background-color: #f0f9ff; border-left: 4px solid #3b82f6; padding: 16px; margin: 24px 0; border-radius: 0 4px 4px 0;">
-                                <p style="margin: 0; color: #1e40af; font-size: 14px;">
-                                    <strong>Recuerda:</strong> Mantener tus datos actualizados nos ayuda a brindarte un mejor servicio médico y comunicarnos contigo de manera efectiva.
-                                </p>
-                            </div>
-                            
-                            <p style="margin: 24px 0 0 0; color: #4b5563; font-size: 16px;">
-                                Si tienes alguna pregunta sobre estos cambios, no dudes en contactarnos. Estamos aquí para ayudarte.
-                            </p>
-                        </td>
-                    </tr>
-                    
-                    <!-- Footer -->
-                    <tr>
-                        <td style="background-color: #f9fafb; padding: 30px; text-align: center; border-top: 1px solid #e5e7eb;">
-                            <p style="margin: 0 0 12px 0; color: #6b7280; font-size: 14px;">
-                                Hospital SDLG - Manteniendo tu información segura y actualizada
-                            </p>
-                            <p style="margin: 0; color: #9ca3af; font-size: 12px;">
-                                Este correo fue enviado automáticamente. Por favor, no respondas a este mensaje.
-                            </p>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
-</body>
-</html>
+{% extends "emails/base_email.html" %}
+
+{% block header_background %}background: linear-gradient(135deg, #7c3aed 0%, #8b5cf6 100%);{% endblock %}
+{% block header_subtitle %}{{ action_summary or "Actualización de información" }}{% endblock %}
+
+{% block body %}
+<div style="text-align: center;">
+    <div class="icon-circle info" style="background: #ede9fe; color: #7c3aed;">📝</div>
+</div>
+
+<h2 class="title" style="text-align: center;">Actualización de datos</h2>
+<p class="text">Estimado/a {{ first_name }} {{ last_name }},</p>
+<p class="text">
+    Te informamos que se han actualizado algunos datos en tu perfil de Hospital SDLG. A continuación, encontrarás el detalle de los cambios realizados:
+</p>
+
+<div class="panel panel--accent">
+    <h3 class="subtitle">Datos actualizados:</h3>
+    <ul class="info-grid">
+        {% for field, reason in data_to_update.items() %}
+        <li class="info-item">
+            <p class="info-label">{{ field }}</p>
+            <p class="info-value">Motivo: {{ reason }}</p>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+
+<div class="panel panel--warning">
+    <p class="text" style="margin: 0;">
+        <strong>Importante:</strong> Si no reconoces estos cambios o crees que se trata de un error, contacta inmediatamente con nuestro equipo de soporte.
+    </p>
+</div>
+
+<div class="panel panel--info">
+    <p class="text" style="margin: 0;">
+        <strong>Recuerda:</strong> Mantener tus datos actualizados nos ayuda a brindarte un mejor servicio médico y comunicarnos contigo de manera efectiva.
+    </p>
+</div>
+
+<p class="text">
+    Si tienes alguna pregunta sobre estos cambios, no dudes en contactarnos. Estamos aquí para ayudarte.
+</p>
+{% endblock %}

--- a/app/templates/emails/verification_email.html
+++ b/app/templates/emails/verification_email.html
@@ -1,84 +1,29 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Verificación de correo electrónico</title>
-</head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; background-color: #f8fafc; line-height: 1.6;">
-    <table role="presentation" style="width: 100%; border-collapse: collapse; margin: 0; padding: 0;">
-        <tr>
-            <td style="padding: 40px 20px;">
-                <table role="presentation" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); overflow: hidden;">
-                    <!-- Header -->
-                    <tr>
-                        <td style="background: linear-gradient(135deg, #059669 0%, #10b981 100%); padding: 40px 30px; text-align: center;">
-                            <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px;">
-                                Hospital SDLG
-                            </h1>
-                            <p style="margin: 8px 0 0 0; color: #a7f3d0; font-size: 16px; font-weight: 400;">
-                                Verificación de correo electrónico
-                            </p>
-                        </td>
-                    </tr>
-                    
-                    <!-- Content -->
-                    <tr>
-                        <td style="padding: 40px 30px;">
-                            <div style="text-align: center; margin-bottom: 30px;">
-                                <div style="display: inline-block; width: 60px; height: 60px; background-color: #d1fae5; border-radius: 50%; position: relative;">
-                                    <span style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 24px; color: #059669;">✉️</span>
-                                </div>
-                            </div>
-                            
-                            <h2 style="margin: 0 0 20px 0; color: #1f2937; font-size: 24px; font-weight: 600; text-align: center;">
-                                Verifica tu correo electrónico
-                            </h2>
-                            
-                            <p style="margin: 0 0 24px 0; color: #4b5563; font-size: 16px; line-height: 1.6; text-align: center;">
-                                Para completar tu registro en Hospital SDLG, necesitamos verificar tu dirección de correo electrónico.
-                            </p>
-                            
-                            <div style="background-color: #ecfdf5; border: 1px solid #10b981; border-radius: 6px; padding: 20px; margin: 24px 0; text-align: center;">
-                                <p style="margin: 0 0 12px 0; color: #065f46; font-size: 14px; font-weight: 600;">
-                                    Tu código de verificación:
-                                </p>
-                                <div style="background-color: #ffffff; border: 2px solid #10b981; border-radius: 8px; padding: 16px; margin: 12px 0;">
-                                    <span style="font-family: 'Courier New', monospace; font-size: 32px; font-weight: 700; color: #1f2937; letter-spacing: 4px;">
-                                        {{ verification_code }}
-                                    </span>
-                                </div>
-                                <p style="margin: 12px 0 0 0; color: #065f46; font-size: 12px;">
-                                    Este código expira en 10 minutos
-                                </p>
-                            </div>
-                            
-                            <div style="background-color: #f0f9ff; border-left: 4px solid #3b82f6; padding: 16px; margin: 24px 0; border-radius: 0 4px 4px 0;">
-                                <p style="margin: 0; color: #1e40af; font-size: 14px;">
-                                    <strong>Siguiente paso:</strong> Ingresa este código en la página de verificación para activar tu cuenta y acceder a todos nuestros servicios médicos.
-                                </p>
-                            </div>
-                            
-                            <p style="margin: 24px 0 0 0; color: #6b7280; font-size: 14px; text-align: center;">
-                                Una vez verificado, podrás agendar citas y acceder a tu historial médico.
-                            </p>
-                        </td>
-                    </tr>
-                    
-                    <!-- Footer -->
-                    <tr>
-                        <td style="background-color: #f9fafb; padding: 30px; text-align: center; border-top: 1px solid #e5e7eb;">
-                            <p style="margin: 0 0 12px 0; color: #6b7280; font-size: 14px;">
-                                Hospital SDLG - Tu salud es nuestra prioridad
-                            </p>
-                            <p style="margin: 0; color: #9ca3af; font-size: 12px;">
-                                Este correo fue enviado automáticamente. Por favor, no respondas a este mensaje.
-                            </p>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
-</body>
-</html>
+{% extends "emails/base_email.html" %}
+
+{% block header_background %}background: linear-gradient(135deg, #059669 0%, #10b981 100%);{% endblock %}
+{% block header_subtitle %}{{ action_summary or "Verificación de correo electrónico" }}{% endblock %}
+
+{% block body %}
+<div style="text-align: center;">
+    <div class="icon-circle success">✉️</div>
+</div>
+
+<h2 class="title" style="text-align: center;">Verifica tu correo electrónico</h2>
+<p class="text" style="text-align: center;">
+    Para completar tu registro en Hospital SDLG, necesitamos verificar tu dirección de correo electrónico.
+</p>
+
+<div class="panel panel--success" style="text-align: center;">
+    <p class="subtitle" style="margin-bottom: 12px;">Tu código de verificación:</p>
+    <div class="code-badge" style="border-color: #10b981;">{{ verification_code }}</div>
+    <p class="muted" style="margin-top: 12px;">Este código expira en 10 minutos</p>
+</div>
+
+<div class="panel panel--info">
+    <p class="text" style="margin: 0;">
+        <strong>Siguiente paso:</strong> Ingresa este código en la página de verificación para activar tu cuenta y acceder a todos nuestros servicios médicos.
+    </p>
+</div>
+
+<p class="muted" style="text-align: center;">Una vez verificado, podrás agendar citas y acceder a tu historial médico.</p>
+{% endblock %}

--- a/app/templates/emails/warning_google_account_email.html
+++ b/app/templates/emails/warning_google_account_email.html
@@ -1,151 +1,56 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Advertencia - Cuenta de Google</title>
-</head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; background-color: #f8fafc; line-height: 1.6;">
-    <table role="presentation" style="width: 100%; border-collapse: collapse; margin: 0; padding: 0;">
-        <tr>
-            <td style="padding: 40px 20px;">
-                <table role="presentation" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); overflow: hidden;">
-                    <!-- Header -->
-                    <tr>
-                        <td style="background: linear-gradient(135deg, #dc2626 0%, #f59e0b 100%); padding: 40px 30px; text-align: center;">
-                            <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px;">
-                                Hospital SDLG
-                            </h1>
-                            <p style="margin: 8px 0 0 0; color: #fef3c7; font-size: 16px; font-weight: 400;">
-                                ⚠️ Acción requerida - Cuenta de Google
-                            </p>
-                        </td>
-                    </tr>
+{% extends "emails/base_email.html" %}
 
-                    <!-- Content -->
-                    <tr>
-                        <td style="padding: 40px 30px;">
-                            <div style="text-align: center; margin-bottom: 30px;">
-                                <div style="display: inline-block; width: 80px; height: 80px; background-color: #fef2f2; border-radius: 50%; position: relative; border: 3px solid #fecaca;">
-                                    <span style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 32px; color: #dc2626;">⚠️</span>
-                                </div>
-                            </div>
+{% block header_background %}background: linear-gradient(135deg, #dc2626 0%, #f59e0b 100%);{% endblock %}
+{% block header_subtitle %}{{ action_summary or "Acción requerida - Cuenta de Google" }}{% endblock %}
 
-                            <h2 style="margin: 0 0 20px 0; color: #dc2626; font-size: 24px; font-weight: 700; text-align: center;">
-                                Advertencia Importante
-                            </h2>
+{% block body %}
+<div style="text-align: center;">
+    <div class="icon-circle danger" style="width: 80px; height: 80px; font-size: 32px;">⚠️</div>
+</div>
 
-                            <p style="margin: 0 0 24px 0; color: #4b5563; font-size: 16px; line-height: 1.6;">
-                                Estimado/a {{ first_name }} {{ last_name }},
-                            </p>
+<h2 class="title" style="text-align: center; color: #dc2626;">Advertencia importante</h2>
+<p class="text">Estimado/a {{ first_name }} {{ last_name }},</p>
+<p class="text">Te contactamos para informarte sobre el estado de tu cuenta vinculada con Google en Hospital SDLG.</p>
 
-                            <p style="margin: 0 0 24px 0; color: #4b5563; font-size: 16px; line-height: 1.6;">
-                                Te contactamos para informarte sobre el estado de tu cuenta vinculada con Google en Hospital SDLG.
-                            </p>
+<div class="panel panel--danger" style="text-align: center;">
+    <div class="icon-circle danger" style="margin-bottom: 12px;">⏰</div>
+    <h3 class="subtitle" style="color: #991b1b;">Tu cuenta será eliminada en:</h3>
+    <div class="code-badge" style="border-color: #dc2626; color: #dc2626;">{{ days.days }} días</div>
+    <p class="muted" style="margin-top: 12px;">Si no tomas acción, perderás acceso permanentemente.</p>
+</div>
 
-                            <!-- Contador de días crítico -->
-                            <div style="background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%); border: 2px solid #dc2626; border-radius: 8px; padding: 24px; margin: 24px 0; text-align: center;">
-                                <div style="margin-bottom: 16px;">
-                                    <span style="font-size: 48px; color: #dc2626;">⏰</span>
-                                </div>
-                                <h3 style="margin: 0 0 12px 0; color: #991b1b; font-size: 20px; font-weight: 700;">
-                                    Tu cuenta será eliminada en:
-                                </h3>
-                                <div style="background-color: #ffffff; border: 2px solid #dc2626; border-radius: 8px; padding: 16px; margin: 12px 0;">
-                                    <span style="font-family: 'Courier New', monospace; font-size: 36px; font-weight: 900; color: #dc2626;">
-                                        {{ days.days }} días
-                                    </span>
-                                </div>
-                                <p style="margin: 12px 0 0 0; color: #991b1b; font-size: 14px; font-weight: 600;">
-                                    Si no tomas acción, perderás acceso permanentemente
-                                </p>
-                            </div>
+<div class="panel panel--warning">
+    <h3 class="subtitle">¿Por qué está programada la eliminación?</h3>
+    <p class="text" style="margin: 0;">
+        Tu cuenta vinculada con Google ha permanecido inactiva por un período prolongado. Como medida de seguridad y para cumplir con nuestras políticas de protección de datos, las cuentas inactivas son programadas para eliminación automática.
+    </p>
+</div>
 
-                            <!-- Razón de la eliminación -->
-                            <div style="background-color: #fffbeb; border-left: 4px solid #f59e0b; padding: 20px; margin: 24px 0; border-radius: 0 6px 6px 0;">
-                                <h3 style="margin: 0 0 12px 0; color: #92400e; font-size: 18px; font-weight: 600;">
-                                    ¿Por qué está programada la eliminación?
-                                </h3>
-                                <p style="margin: 0; color: #78350f; font-size: 14px; line-height: 1.5;">
-                                    Tu cuenta vinculada con Google ha permanecido inactiva por un período prolongado. Como medida de seguridad y para cumplir con nuestras políticas de protección de datos, las cuentas inactivas son programadas para eliminación automática.
-                                </p>
-                            </div>
+<div class="panel panel--success">
+    <h3 class="subtitle" style="text-align: center;">Cómo mantener tu cuenta activa:</h3>
+    <ol class="list">
+        <li><strong>Inicia sesión</strong> en tu cuenta de Hospital SDLG.</li>
+        <li><strong>Actualiza tu información</strong> personal si es necesario.</li>
+        <li><strong>Utiliza cualquier servicio</strong> (agendar cita, consultar historial, etc.).</li>
+        <li><strong>Confirma que deseas mantener</strong> tu cuenta activa.</li>
+    </ol>
+</div>
 
-                            <!-- Acciones para evitar eliminación -->
-                            <div style="background-color: #f0fdf4; border: 2px solid #22c55e; border-radius: 8px; padding: 24px; margin: 24px 0;">
-                                <h3 style="margin: 0 0 16px 0; color: #15803d; font-size: 18px; font-weight: 600; text-align: center;">
-                                    🛡️ Cómo mantener tu cuenta activa:
-                                </h3>
-                                <div style="background-color: #ffffff; border-radius: 6px; padding: 20px;">
-                                    <ol style="margin: 0; padding-left: 20px; color: #166534;">
-                                        <li style="margin-bottom: 12px; line-height: 1.5; font-size: 15px;">
-                                            <strong>Inicia sesión</strong> en tu cuenta de Hospital SDLG
-                                        </li>
-                                        <li style="margin-bottom: 12px; line-height: 1.5; font-size: 15px;">
-                                            <strong>Actualiza tu información</strong> personal si es necesario
-                                        </li>
-                                        <li style="margin-bottom: 12px; line-height: 1.5; font-size: 15px;">
-                                            <strong>Utiliza cualquier servicio</strong> (agendar cita, consultar historial, etc.)
-                                        </li>
-                                        <li style="margin-bottom: 0; line-height: 1.5; font-size: 15px;">
-                                            <strong>Confirma que deseas mantener</strong> tu cuenta activa
-                                        </li>
-                                    </ol>
-                                </div>
-                            </div>
+<div class="panel panel--info">
+    <h4 class="subtitle">Información importante:</h4>
+    <ul class="list">
+        <li>Una vez eliminada, no podrás recuperar tu historial médico digital.</li>
+        <li>Perderás acceso a citas programadas y recordatorios.</li>
+        <li>Tendrás que crear una nueva cuenta para usar nuestros servicios.</li>
+        <li>El proceso es irreversible después de la fecha límite.</li>
+    </ul>
+</div>
 
-                            <!-- Botón de acción (simulado) -->
-                            <div style="text-align: center; margin: 32px 0;">
-                                <div style="display: inline-block; background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%); border-radius: 8px; padding: 16px 32px; box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);">
-                                    <span style="color: #ffffff; font-size: 16px; font-weight: 600; text-decoration: none;">
-                                        🔗 Acceder a mi cuenta ahora
-                                    </span>
-                                </div>
-                                <p style="margin: 12px 0 0 0; color: #6b7280; font-size: 12px;">
-                                    Haz clic para mantener tu cuenta activa
-                                </p>
-                            </div>
+<div class="panel panel--warning">
+    <p class="text" style="margin: 0;">
+        <strong>¿Necesitas ayuda?</strong> Si tienes problemas para acceder a tu cuenta o crees que esto es un error, contacta inmediatamente a nuestro equipo de soporte técnico.
+    </p>
+</div>
 
-                            <!-- Información adicional -->
-                            <div style="background-color: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; padding: 20px; margin: 24px 0;">
-                                <h4 style="margin: 0 0 12px 0; color: #475569; font-size: 16px; font-weight: 600;">
-                                    📋 Información importante:
-                                </h4>
-                                <ul style="margin: 0; padding-left: 20px; color: #64748b; font-size: 14px;">
-                                    <li style="margin-bottom: 8px;">Una vez eliminada, no podrás recuperar tu historial médico digital</li>
-                                    <li style="margin-bottom: 8px;">Perderás acceso a citas programadas y recordatorios</li>
-                                    <li style="margin-bottom: 8px;">Tendrás que crear una nueva cuenta para usar nuestros servicios</li>
-                                    <li style="margin-bottom: 0;">Este proceso es irreversible después de la fecha límite</li>
-                                </ul>
-                            </div>
-
-                            <!-- Contacto de emergencia -->
-                            <div style="background-color: #fef3c7; border-left: 4px solid #f59e0b; padding: 16px; margin: 24px 0; border-radius: 0 4px 4px 0;">
-                                <p style="margin: 0; color: #92400e; font-size: 14px;">
-                                    <strong>¿Necesitas ayuda?</strong> Si tienes problemas para acceder a tu cuenta o crees que esto es un error, contacta inmediatamente a nuestro equipo de soporte técnico.
-                                </p>
-                            </div>
-
-                            <p style="margin: 24px 0 0 0; color: #4b5563; font-size: 16px; text-align: center;">
-                                Gracias por confiar en Hospital SDLG para el cuidado de tu salud.
-                            </p>
-                        </td>
-                    </tr>
-
-                    <!-- Footer -->
-                    <tr>
-                        <td style="background-color: #f9fafb; padding: 30px; text-align: center; border-top: 1px solid #e5e7eb;">
-                            <p style="margin: 0 0 12px 0; color: #6b7280; font-size: 14px;">
-                                Hospital SDLG - Protegiendo tu información médica
-                            </p>
-                            <p style="margin: 0; color: #9ca3af; font-size: 12px;">
-                                Este es un correo automático de seguridad. Por favor, no respondas a este mensaje.
-                            </p>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
-</body>
-</html>
+<p class="text" style="text-align: center;">Gracias por confiar en Hospital SDLG para el cuidado de tu salud.</p>
+{% endblock %}

--- a/app/templates/emails/welcome_email.html
+++ b/app/templates/emails/welcome_email.html
@@ -1,70 +1,29 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Bienvenido a Hospital SDLG</title>
-</head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif; background-color: #f8fafc; line-height: 1.6;">
-    <table role="presentation" style="width: 100%; border-collapse: collapse; margin: 0; padding: 0;">
-        <tr>
-            <td style="padding: 40px 20px;">
-                <table role="presentation" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); overflow: hidden;">
-                    <!-- Header -->
-                    <tr>
-                        <td style="background: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%); padding: 40px 30px; text-align: center;">
-                            <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: -0.5px;">
-                                Hospital SDLG
-                            </h1>
-                            <p style="margin: 8px 0 0 0; color: #e0e7ff; font-size: 16px; font-weight: 400;">
-                                Cuidando tu salud con excelencia
-                            </p>
-                        </td>
-                    </tr>
-                    
-                    <!-- Content -->
-                    <tr>
-                        <td style="padding: 40px 30px;">
-                            <h2 style="margin: 0 0 20px 0; color: #1f2937; font-size: 24px; font-weight: 600;">
-                                ¡Bienvenido, {{ first_name }} {{ last_name }}!
-                            </h2>
-                            
-                            <p style="margin: 0 0 20px 0; color: #4b5563; font-size: 16px; line-height: 1.6;">
-                                Nos complace darte la bienvenida a Hospital SDLG. Tu cuenta ha sido creada exitosamente y ya puedes acceder a todos nuestros servicios médicos digitales.
-                            </p>
-                            
-                            <div style="background-color: #f0f9ff; border-left: 4px solid #3b82f6; padding: 20px; margin: 24px 0; border-radius: 0 4px 4px 0;">
-                                <h3 style="margin: 0 0 12px 0; color: #1e40af; font-size: 18px; font-weight: 600;">
-                                    ¿Qué puedes hacer ahora?
-                                </h3>
-                                <ul style="margin: 0; padding-left: 20px; color: #374151;">
-                                    <li style="margin-bottom: 8px;">Agendar citas médicas en línea</li>
-                                    <li style="margin-bottom: 8px;">Consultar tu historial médico</li>
-                                    <li style="margin-bottom: 8px;">Recibir resultados de laboratorio</li>
-                                    <li style="margin-bottom: 0;">Comunicarte con nuestro equipo médico</li>
-                                </ul>
-                            </div>
-                            
-                            <p style="margin: 24px 0 0 0; color: #4b5563; font-size: 16px;">
-                                Si tienes alguna pregunta o necesitas asistencia, nuestro equipo de soporte está disponible las 24 horas.
-                            </p>
-                        </td>
-                    </tr>
-                    
-                    <!-- Footer -->
-                    <tr>
-                        <td style="background-color: #f9fafb; padding: 30px; text-align: center; border-top: 1px solid #e5e7eb;">
-                            <p style="margin: 0 0 12px 0; color: #6b7280; font-size: 14px;">
-                                Hospital SDLG - Comprometidos con tu bienestar
-                            </p>
-                            <p style="margin: 0; color: #9ca3af; font-size: 12px;">
-                                Este correo fue enviado automáticamente. Por favor, no respondas a este mensaje.
-                            </p>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
-</body>
-</html>
+{% extends "emails/base_email.html" %}
+
+{% block header_subtitle %}{{ action_summary or "Bienvenido a Hospital SDLG" }}{% endblock %}
+
+{% block body %}
+<div style="text-align: center;">
+    <div class="icon-circle info">👋</div>
+</div>
+
+<h2 class="title">¡Bienvenido, {{ first_name }} {{ last_name }}!</h2>
+<p class="text">
+    Nos complace darte la bienvenida a Hospital SDLG. Tu cuenta ha sido creada exitosamente y ya puedes acceder
+    a todos nuestros servicios médicos digitales.
+</p>
+
+<div class="panel panel--accent">
+    <h3 class="subtitle">¿Qué puedes hacer ahora?</h3>
+    <ul class="list">
+        <li>Agendar citas médicas en línea</li>
+        <li>Consultar tu historial médico</li>
+        <li>Recibir resultados de laboratorio</li>
+        <li>Comunicarte con nuestro equipo médico</li>
+    </ul>
+</div>
+
+<p class="text">
+    Si tienes alguna pregunta o necesitas asistencia, nuestro equipo de soporte está disponible las 24 horas.
+</p>
+{% endblock %}

--- a/test/test_medic_area_patients_endpoint.py
+++ b/test/test_medic_area_patients_endpoint.py
@@ -1,0 +1,173 @@
+import importlib.util
+import json
+import sys
+import types
+import uuid
+from pathlib import Path
+
+import orjson
+import pytest
+from fastapi import FastAPI
+from fastapi import HTTPException, status
+from fastapi import Request
+from sqlmodel import Session, SQLModel, create_engine
+
+
+class _DummyItem:
+    def __init__(self, name: str | None = None, content: dict | None = None):
+        self.item_name = name or ""
+        self.content = content or {}
+        self.expired_at = None
+        self.created_at = None
+        self.updated_at = None
+        self.uuid_id = str(uuid.uuid4())
+
+    def to_json(self) -> str:
+        return json.dumps({"name": self.item_name, "content": self.content})
+
+
+class _DummySet:
+    def __init__(self, name: str | None = None):
+        self.name = name or ""
+
+    def items(self):
+        return []
+
+    def to_json(self) -> str:
+        return json.dumps({"name": self.name, "content": []})
+
+
+sys.modules.setdefault(
+    "encript_storage",
+    types.SimpleNamespace(
+        Set=_DummySet,
+        Item=_DummyItem,
+        py_read_set=lambda name: _DummySet(name),
+        py_create_set=lambda name: _DummySet(name),
+        py_save_data=lambda *_, **__: None,
+        py_find_item_in_set=lambda *_, **__: _DummyItem(),
+        py_create_item=lambda *_, **__: _DummyItem(),
+        py_add_item=lambda *_, **__: None,
+        py_update_item_content_by_name=lambda *_, **__: None,
+    ),
+)
+sys.modules.setdefault(
+    "polars",
+    types.SimpleNamespace(DataFrame=object, Series=object, col=lambda *_, **__: None),
+)
+sys.modules.setdefault(
+    "stripe", types.SimpleNamespace()
+)
+spec = importlib.util.spec_from_file_location(
+    "app.api.medic_area",
+    Path(__file__).resolve().parent.parent / "app" / "api" / "medic_area.py",
+)
+medic_area = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(medic_area)
+
+get_patients_by_doctor = medic_area.get_patients_by_doctor
+
+from app.models import Appointments, Departments, Doctors, Locations, Specialties, User
+
+
+@pytest.fixture()
+def session():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def build_specialty(session: Session) -> Specialties:
+    location = Locations(name="loc", description="location")
+    department = Departments(name="dep", description="department", location=location)
+    specialty = Specialties(name="spec", description="specialty", departament=department)
+    session.add_all([location, department, specialty])
+    session.commit()
+    session.refresh(specialty)
+    return specialty
+
+
+def build_request(user: User | Doctors) -> Request:
+    request = Request({"type": "http", "app": FastAPI(), "headers": []})
+    request.state.user = user
+    return request
+
+
+def build_doctor(*, session: Session, specialty: Specialties, email: str) -> Doctors:
+    doctor = Doctors(
+        name=email,
+        email=email,
+        password="Password123!",
+        speciality_id=specialty.id,
+        dni="12345678",
+    )
+    session.add(doctor)
+    session.commit()
+    session.refresh(doctor)
+    return doctor
+
+
+def build_user(*, session: Session, email: str, is_admin: bool = False, is_superuser: bool = False) -> User:
+    user = User(
+        name=email,
+        email=email,
+        password="Password123!",
+        dni="12345678",
+        is_admin=is_admin,
+        is_superuser=is_superuser,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+@pytest.mark.asyncio
+async def test_get_patients_returns_404_when_doctor_missing(session: Session):
+    admin_user = build_user(session=session, email="admin@example.com", is_admin=True)
+    request = build_request(admin_user)
+
+    with pytest.raises(HTTPException) as exc:
+        await get_patients_by_doctor(request, uuid.uuid4(), session, current_user=admin_user)
+
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_get_patients_rejects_doctor_without_access(session: Session):
+    specialty = build_specialty(session)
+    primary_doctor = build_doctor(session=session, specialty=specialty, email="doc@example.com")
+    outsider_doctor = build_doctor(session=session, specialty=specialty, email="outsider@example.com")
+    request = build_request(outsider_doctor)
+
+    with pytest.raises(HTTPException) as exc:
+        await get_patients_by_doctor(request, primary_doctor.id, session, current_user=outsider_doctor)
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_get_patients_filters_duplicates_and_null_users(session: Session):
+    specialty = build_specialty(session)
+    doctor = build_doctor(session=session, specialty=specialty, email="doc@example.com")
+    admin_user = build_user(session=session, email="admin@example.com", is_admin=True)
+    patient = build_user(session=session, email="patient@example.com")
+
+    session.add_all(
+        [
+            Appointments(user=patient, doctor=doctor),
+            Appointments(user=patient, doctor=doctor),
+            Appointments(doctor=doctor),
+        ]
+    )
+    session.commit()
+
+    request = build_request(admin_user)
+    response = await get_patients_by_doctor(request, doctor.id, session, current_user=admin_user)
+    payload = orjson.loads(response.body)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(payload) == 1
+    assert payload[0]["id"] == str(patient.id)


### PR DESCRIPTION
# Summary
- add a reusable base email layout with shared styling and support footer
- refactor existing email templates to extend the base design and use common components
- update EmailService to inject shared context such as action summaries and support links when rendering emails