### PR TITLE
Validate doctor turn creation inputs

### DIFF
--- a/app/api/medic_area.py
+++ b/app/api/medic_area.py
@@ -2038,10 +2038,25 @@ async def get_turn_by_id(request: Request, session: SessionDep, turn_id: UUID):
 @turns.post("/add", response_model=PayTurnResponse)
 async def create_turn(request: Request, session: SessionDep, turn: TurnsCreate):
     user: User | None = request.state.user
+    scopes = getattr(request.state, "scopes", []) or []
+    doctor: Doctors | None = None
 
-    if "doc" in request.state.scopes:
+    if "doc" in scopes:
         if turn.user_id is None:
-            raise HTTPException(status_code=400, detail="user_id is required")
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="user_id is required")
+
+        if isinstance(user, Doctors):
+            doctor = user
+        elif user:
+            doctor = session.get(Doctors, user.id)
+
+        if doctor is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Authenticated doctor not found")
+
+        if turn.doctor_id is None:
+            turn.doctor_id = doctor.id
+        elif turn.doctor_id != doctor.id:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="doctor_id must match the authenticated doctor")
 
     elif user:
         turn.user_id = user.id
@@ -2049,14 +2064,32 @@ async def create_turn(request: Request, session: SessionDep, turn: TurnsCreate):
     else:
         raise HTTPException(status_code=500, detail="Internal Error")
 
+    patient = session.get(User, turn.user_id)
+    if patient is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Patient not found")
+
+    if turn.doctor_id:
+        doctor = doctor or session.get(Doctors, turn.doctor_id)
+        if doctor is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Doctor not found")
+
     try:
         new_turn, new_appointment = await TurnAndAppointmentRepository.create_turn_and_appointment(
             session=session,
-            turn=turn
+            turn=turn,
+            doctor=doctor
         )
 
         if not new_turn:
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=new_appointment)
+            lowered_message = (new_appointment or "").lower()
+
+            status_code_error = status.HTTP_409_CONFLICT
+            if "schedule" in lowered_message or "agenda" in lowered_message:
+                status_code_error = status.HTTP_404_NOT_FOUND
+            elif "service" in lowered_message or "doctor" in lowered_message:
+                status_code_error = status.HTTP_400_BAD_REQUEST
+
+            raise HTTPException(status_code=status_code_error, detail=new_appointment)
 
         response = await StripeServices.proces_payment(
             price=new_turn.price_total(),

--- a/app/schemas/medica_area/turns.py
+++ b/app/schemas/medica_area/turns.py
@@ -32,6 +32,7 @@ class TurnsCreate(BaseModel):
     date: date_type
     date_created: date_type = datetime.now().date()
     user_id: Optional[UUID] = None
+    doctor_id: Optional[UUID] = None
     services: List[UUID] = []
     time: time_type
     health_insurance: Optional[UUID] = None


### PR DESCRIPTION
# Summary
- allow doctor-scope turn creation to provide a matching doctor_id and verify patient/doctor records before proceeding
- support selecting a specific doctor when building turn and appointment records while enforcing schedule availability
- return clearer 400/404 errors for missing patients or schedules during turn creation
