### PR TITLE
Fix appointment service serialization

### DIFF
--- a/app/api/medic_area.py
+++ b/app/api/medic_area.py
@@ -15,7 +15,7 @@ from fastapi.responses import ORJSONResponse
 
 from sqlmodel import select
 
-from typing import List, Optional, Dict, Annotated, TypeVar
+from typing import List, Optional, Dict, Annotated, TypeVar, Tuple
 
 from rich import print
 from rich.console import Console
@@ -2198,6 +2198,26 @@ appointments = APIRouter(
     ]
 )
 
+
+def _get_primary_service(turn) -> Tuple[Optional[UUID], Optional[dict]]:
+    """Return first service associated with a turn, if any."""
+
+    if not turn or not turn.services:
+        return None, None
+
+    service = turn.services[0]
+    serialized_service = ServiceResponse(
+        id=service.id,
+        name=service.name,
+        description=service.description,
+        price=service.price,
+        specialty_id=service.specialty_id,
+        icon_code=service.icon_code,
+    ).model_dump()
+
+    return service.id, serialized_service
+
+
 @appointments.get("/", response_model=List[AppointmentResponse])
 async def get_appointments(request: Request, session: SessionDep):
     if not request.state.user.is_superuser and not "doc" in request.state.scopes:
@@ -2207,17 +2227,19 @@ async def get_appointments(request: Request, session: SessionDep):
     result: List["Appointments"] = session.exec(statement).all()
     serialized_appointments: List[AppointmentResponse] = []
     for appointment in result:
+        service_id, serialized_service = _get_primary_service(appointment.turn)
         serialized_appointments.append(
             AppointmentResponse(
                 id=appointment.id,
                 user_id=appointment.user_id,
                 doctor_id=appointment.doctor_id,
                 turn_id=appointment.turn_id,
-                service_id=appointment.turn.service_id,
+                service_id=service_id,
                 date=appointment.turn.date,
                 date_created=appointment.turn.date_created,
                 date_limit=appointment.turn.date_limit,
                 state=appointment.turn.state,
+                service=serialized_service,
             ).model_dump()
         )
 

--- a/app/api/medic_area/appointments.py
+++ b/app/api/medic_area/appointments.py
@@ -1,5 +1,6 @@
 """Appointment routes."""
-from typing import List
+from typing import List, Optional, Tuple
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import ORJSONResponse
@@ -8,6 +9,7 @@ from sqlmodel import select
 from app.db.main import SessionDep
 from app.models import Appointments
 from app.schemas.medica_area import AppointmentResponse
+from app.schemas.medica_area.services import ServiceResponse
 
 from .common import auth_dependency, default_response_class
 
@@ -20,6 +22,30 @@ router = APIRouter(
 )
 
 
+def _get_primary_service(turn) -> Tuple[Optional[UUID], Optional[dict]]:
+    """Return the primary service (first one) associated with a turn.
+
+    The legacy schema stores services as a list in the turn, so we pick the
+    first one to maintain backwards compatibility with consumers expecting a
+    singular service_id/service payload.
+    """
+
+    if not turn or not turn.services:
+        return None, None
+
+    service = turn.services[0]
+    serialized_service = ServiceResponse(
+        id=service.id,
+        name=service.name,
+        description=service.description,
+        price=service.price,
+        specialty_id=service.specialty_id,
+        icon_code=service.icon_code,
+    ).model_dump()
+
+    return service.id, serialized_service
+
+
 @router.get("/", response_model=List[AppointmentResponse])
 async def get_appointments(request: Request, session: SessionDep):
     if not request.state.user.is_superuser and "doc" not in request.state.scopes:
@@ -29,17 +55,19 @@ async def get_appointments(request: Request, session: SessionDep):
     result = session.exec(statement).all()
     serialized_appointments: List[AppointmentResponse] = []
     for appointment in result:
+        service_id, serialized_service = _get_primary_service(appointment.turn)
         serialized_appointments.append(
             AppointmentResponse(
                 id=appointment.id,
                 user_id=appointment.user_id,
                 doctor_id=appointment.doctor_id,
                 turn_id=appointment.turn_id,
-                service_id=appointment.turn.service_id,
+                service_id=service_id,
                 date=appointment.turn.date,
                 date_created=appointment.turn.date_created,
                 date_limit=appointment.turn.date_limit,
                 state=appointment.turn.state,
+                service=serialized_service,
             ).model_dump()
         )
 


### PR DESCRIPTION
# Summary

- add helper to safely serialize the primary service from appointment turns
- update appointment endpoints to include serialized service data and avoid missing attribute access
