### PR TITLE
Rename cash metadata columns to avoid SQLAlchemy conflict

### DIFF
--- a/app/core/services/stripe_payment.py
+++ b/app/core/services/stripe_payment.py
@@ -177,7 +177,7 @@ class StripeServices:
                             discount=discount,
                             transaction_type="income",
                             reference_id=payment_id or turn_id,
-                            metadata={
+                            transaction_metadata={
                                 "turn_id": str(turn_id),
                                 "payment_id": str(payment_id) if payment_id else None,
                                 "payment_method": payment_method,
@@ -191,7 +191,7 @@ class StripeServices:
                 open_cash.apply_transaction(income_delta=total)
                 open_cash.time_transaction = now.time()
                 open_cash.reference_id = open_cash.reference_id or payment_id or turn_id
-                merged_metadata = dict(open_cash.metadata or {})
+                merged_metadata = dict(open_cash.transaction_metadata or {})
                 merged_metadata.update(
                     {
                         "last_turn_id": str(turn_id),
@@ -199,7 +199,7 @@ class StripeServices:
                         "payment_method": payment_method,
                     }
                 )
-                open_cash.metadata = merged_metadata
+                open_cash.transaction_metadata = merged_metadata
 
                 session.add(open_cash)
                 session.commit()

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -524,7 +524,9 @@ class Cashes(SQLModel, table=True):
     transaction_type: str = Field(default="income", max_length=50, nullable=False)
     reference_id: Optional[UUID] = Field(sa_type=UUID_TYPE, default=None, nullable=True)
     description: Optional[str] = Field(default=None, max_length=255, nullable=True)
-    metadata: Optional[dict] = Field(default=None, sa_column=Column(JSON, nullable=True))
+    transaction_metadata: Optional[dict] = Field(
+        default=None, sa_column=Column("transaction_metadata", JSON, nullable=True)
+    )
     created_by: Optional[UUID] = Field(
         sa_type=UUID_TYPE,
         foreign_key="users.user_id",
@@ -563,7 +565,9 @@ class CashDetails(SQLModel, table=True):
     discount: int = Field(nullable=False, le=100, ge=0)
     transaction_type: str = Field(default="income", max_length=50, nullable=False)
     reference_id: Optional[UUID] = Field(sa_type=UUID_TYPE, default=None, nullable=True)
-    metadata: Optional[dict] = Field(default=None, sa_column=Column(JSON, nullable=True))
+    transaction_metadata: Optional[dict] = Field(
+        default=None, sa_column=Column("transaction_metadata", JSON, nullable=True)
+    )
     created_by: Optional[UUID] = Field(
         sa_type=UUID_TYPE,
         foreign_key="users.user_id",


### PR DESCRIPTION
# Summary
- rename cash and cash detail metadata fields to transaction_metadata to avoid SQLAlchemy reserved attribute conflicts
- update Stripe payment service to use the renamed transaction metadata fields when persisting payment details