### PR TITLE
Fix relationship target definitions for payments

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -5,7 +5,7 @@ from sqlmodel import SQLModel, Field, Relationship, Session
 
 from sqlalchemy import Column, JSON, UUID as UUID_TYPE, VARCHAR, event
 from sqlalchemy import Enum as SQLEnum
-from sqlalchemy.orm import declarative_mixin
+from sqlalchemy.orm import declarative_mixin, relationship
 
 from typing import Optional, List, Dict, Any, TYPE_CHECKING
 
@@ -366,7 +366,9 @@ class Turns(BaseModelTurns, table=True):
     )
 
     appointment: Optional["Appointments"] = Relationship(back_populates="turn")
-    payment: Optional["Payment"] = Relationship(back_populates="turn")
+    payment: Optional["Payment"] = Relationship(
+        sa_relationship=relationship("Payment", back_populates="turn", uselist=False)
+    )
     documents: List["TurnDocument"] = Relationship(back_populates="turn")
     document_downloads: List["TurnDocumentDownload"] = Relationship(back_populates="turn")
 

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 
 from sqlalchemy import JSON, Column, Enum as SQLEnum
 from sqlalchemy import UUID as UUID_TYPE
+from sqlalchemy.orm import relationship
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
@@ -73,7 +74,9 @@ class Payment(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
     updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
 
-    turn: Optional["Turns"] = Relationship(back_populates="payment")
+    turn: Optional["Turns"] = Relationship(
+        sa_relationship=relationship("Turns", back_populates="payment", uselist=False)
+    )
     appointment: Optional["Appointments"] = Relationship(back_populates="payments")
     user: Optional["User"] = Relationship(back_populates="payments")
     items: List["PaymentItem"] = Relationship(back_populates="payment")


### PR DESCRIPTION
# Summary
- explicitly define SQLAlchemy relationship targets for payment-to-turn associations to avoid generic mapping errors
-import SQLAlchemy relationship helper where needed for explicit configuration
