### PR TITLE
Fix session usage in password reset confirmation

### DIFF
--- a/app/api/users.py
+++ b/app/api/users.py
@@ -680,7 +680,7 @@ async def update_confirm_password(
     emitter: AuditEmitter = Depends(get_audit_emitter),
 ):
     try:
-        user: User = session_db.exec(
+        user: User = session.exec(
             select(User).where(User.email == email)
         ).first()[0]
 


### PR DESCRIPTION
# Summary
- use the injected session dependency when loading a user during password reset confirmation to avoid errors