### PR TITLE
Expose payment data in turn responses 

### DIFF
--- a/DOCUMENTACION_FUNCIONES.md
+++ b/DOCUMENTACION_FUNCIONES.md
@@ -614,7 +614,8 @@
 - **Método HTTP**: GET
 - **Ruta**: `/medic/turns/`
 - **Autenticación**: Solo superusuarios
-- **Retorna**: Turnos con servicios y citas asociadas
+- **Retorna**: Turnos con servicios, citas asociadas y detalles de pago (`payment`,
+  `payment_url`, `payment_status`) sin necesidad de llamar a `/payments`
 
 #### `get_turns_by_user_id(request: Request, session: SessionDep, user_id: UUID)`
 **Descripción**: Obtiene turnos de un usuario específico.
@@ -624,6 +625,8 @@
   - Lista turnos del usuario
   - Incluye información del médico
   - Incluye servicios solicitados
+- Incluye el estado y URL del pago del turno dentro de la respuesta (`payment`,
+  `payment_url`, `payment_status`), eliminando la necesidad de consultar `/payments`
 - **Serialización**: Funciones helper para departamentos y especialidades
 
 #### `create_turn(request: Request, session: SessionDep, turn: TurnsCreate)`

--- a/app/schemas/medica_area/turns.py
+++ b/app/schemas/medica_area/turns.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, computed_field, field_serializer
 
 from app.schemas import UserRead
 from app.schemas.payment import PaymentRead
+from app.models.payment import PaymentStatus
 
 from .enums import TurnsState
 
@@ -57,6 +58,21 @@ class TurnsResponse(TurnsBase):
     user: Optional[UserRead] = None
     doctor: Optional["DoctorResponse"] = None
     service: Optional[List["ServiceResponse"]] = None
+    payment: Optional[PaymentRead] = None
+
+    @computed_field(return_type=Optional[str])
+    def payment_url(self) -> Optional[str]:
+        if self.payment is None:
+            return None
+
+        return self.payment.payment_url
+
+    @computed_field(return_type=Optional[PaymentStatus])
+    def payment_status(self) -> Optional[PaymentStatus]:
+        if self.payment is None:
+            return None
+
+        return self.payment.status
 
 
 class PayTurnResponse(BaseModel):


### PR DESCRIPTION
# Summary
- add optional payment details and derived payment status/url to TurnsResponse
- preload turn payment relations and serialize PaymentRead across turn endpoints
- document that turn payloads now include payment information without separate /payments calls