### PR TITLE
Add endpoints to recreate and query payment sessions

### DIFF
--- a/app/schemas/payment.py
+++ b/app/schemas/payment.py
@@ -47,6 +47,14 @@ class PaymentCreate(BaseModel):
     gateway_metadata: Optional[dict[str, Any]] = None
 
 
+class PaymentTurnCreate(BaseModel):
+    """Payload para recrear o iniciar una sesión de pago de un turno."""
+
+    turn_id: UUID
+    payment_method: PaymentMethod = PaymentMethod.card
+    gateway_metadata: Optional[dict[str, Any]] = None
+
+
 class PaymentRead(PaymentBase):
     id: UUID
     created_at: datetime


### PR DESCRIPTION
# Summary
- add request schema for recreating payment sessions by turn
- expose POST /payments/turn/ to recreate a payment session for a turn and return payment info
- expose GET /payments/status to retrieve payment details by checkout session id