### PR TITLE
Normalize turn payment serialization

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -366,8 +366,8 @@ class Turns(BaseModelTurns, table=True):
     )
 
     appointment: Optional["Appointments"] = Relationship(back_populates="turn")
-    payment: Optional["Payment"] = Relationship(
-        sa_relationship=relationship("Payment", back_populates="turn", uselist=False)
+    payments: List["Payment"] = Relationship(
+        sa_relationship=relationship("Payment", back_populates="turn")
     )
     documents: List["TurnDocument"] = Relationship(back_populates="turn")
     document_downloads: List["TurnDocumentDownload"] = Relationship(back_populates="turn")

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -76,11 +76,11 @@ class Payment(SQLModel, table=True):
 
     # ---------- RELACIONES ----------
 
-    # Turno (uno a uno)
+    # Turno (muchos pagos pueden apuntar al mismo turno)
     turn: Optional["Turns"] = Relationship(
         sa_relationship=relationship(
             "Turns",
-            back_populates="payment",
+            back_populates="payments",
             uselist=False,
         )
     )


### PR DESCRIPTION
# Summary
- normalize turn response serialization to coerce ORM relations into expected schema fields
- allow turns to hold multiple payments to avoid uselist warnings when several records exist